### PR TITLE
fix: issue #2 - 404 for some collection endpoints

### DIFF
--- a/admin/src/containers/View/components/NavigationItemForm/index.js
+++ b/admin/src/containers/View/components/NavigationItemForm/index.js
@@ -155,7 +155,7 @@ const NavigationItemForm = ({
           (_) => _.collectionName === value,
         );
         if (item) {
-          await getContentTypeEntities(item.collectionName, item.plugin);
+          await getContentTypeEntities(item.endpoint || item.collectionName, item.plugin);
         }
       }
     };

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -13,6 +13,7 @@ const {
   first,
   flatten,
   get,
+  last,
   upperFirst,
   isString,
 } = require("lodash");
@@ -126,14 +127,15 @@ module.exports = {
       )
       .map((key) => {
         const item = strapi.contentTypes[key];
-        const { options, info, collectionName, plugin } = item;
+        const { options, info, collectionName, apiName, plugin } = item;
         const { name, label, description } = info;
         const { isManaged, hidden } = options;
         return {
           name,
           description,
           collectionName,
-          label: upperFirst(collectionName),
+          endpoint: last(apiName) === 's' ? apiName : `${apiName}s`,
+          label: upperFirst(name || collectionName),
           plugin,
           visible: (isManaged || isNil(isManaged)) && !hidden,
         };


### PR DESCRIPTION
## Ticket

Issue #2
_Relationship to Content Type" dropdown throws a 404 when collection names don't match endpoint ids_

## Summary

What does this PR do/solve? 

Fixes a case when collection name doesn't match the api name like in the case:
- Collection name: `blog_posts`
- Api name: `blog-post`