### PR TITLE
feat: re-ordering navigation items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Ticket
+
+https://github.com/VirtusLab/strapi-plugin-navigation/issues/-<your-ticket-#>
+
+## Summary
+
+What does this PR do/solve? 
+
+> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs
+
+## Test Plan
+
+How are you testing the work you're submitting?

--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -16,6 +16,7 @@ import List from "../List";
 import CardItemLevelWrapper from "./CardItemLevelWrapper";
 import CardItemRestore from "./CardItemRestore";
 import pluginId from "../../pluginId";
+import ItemOrdering from "../ItemOrdering";
 
 const Item = (props) => {
   const { 
@@ -24,7 +25,10 @@ const Item = (props) => {
     levelPath = '',
     allowedLevels,
     relatedRef,
+    isFirst = false,
+    isLast = false,
     onItemClick,
+    onItemReOrder,
     onItemRestoreClick,
     onItemLevelAddClick } = props;
   const {
@@ -42,16 +46,21 @@ const Item = (props) => {
     removed,
     menuAttached,
     relatedRef,
+    attachButtons: !(isFirst && isLast),
   };
 
   const { formatMessage } = useIntl();
-
 
   const isNextMenuAllowedLevel = isNumber(allowedLevels) ? level < (allowedLevels - 1) : true;
   const isMenuAllowedLevel = isNumber(allowedLevels) ? level < allowedLevels : true;
   const isExternal = item.type === navigationItemType.EXTERNAL;
   const absolutePath = isExternal ? undefined : `${levelPath === '/' ? '' : levelPath}/${path === '/' ? '' : path}`;
   const hasChildren = !isEmpty(item.items) && !isExternal;
+
+  const handleReOrder = (e, moveBy = 0) => onItemReOrder(e, {
+    ...item,
+    relatedRef,
+  }, moveBy);
 
   return (
     <CardWrapper level={level}>
@@ -79,6 +88,11 @@ const Item = (props) => {
           {isExternal ? externalPath : absolutePath}
         </CardItemPath>
         <ItemFooter {...footerProps} />
+        <ItemOrdering 
+          isFirst={isFirst}
+          isLast={isLast}
+          onChangeOrder={handleReOrder}
+        />
       </CardItem>
       { !(isExternal || removed) && (<CardItemLevelAdd
         color={isNextMenuAllowedLevel ? "primary" : "secondary"}
@@ -90,6 +104,7 @@ const Item = (props) => {
         <List
           items={item.items}
           onItemClick={onItemClick}
+          onItemReOrder={onItemReOrder}
           onItemRestoreClick={onItemRestoreClick}
           onItemLevelAddClick={onItemLevelAddClick}
           as={CardItemLevelWrapper}
@@ -116,6 +131,8 @@ Item.propTypes = {
   relatedRef: PropTypes.object,
   level: PropTypes.number,
   levelPath: PropTypes.string,
+  isFirst: PropTypes.bool,
+  isLast: PropTypes.bool,
   onItemClick: PropTypes.func.isRequired,
   onItemRestoreClick: PropTypes.func.isRequired,
   onItemLevelAddClick: PropTypes.func.isRequired,

--- a/admin/src/components/ItemFooter/Wrapper.js
+++ b/admin/src/components/ItemFooter/Wrapper.js
@@ -6,6 +6,7 @@ const Wrapper = styled.div`
   display: flex;
   padding-top: 1rem;
   margin-top: 1rem;
+  margin-bottom: ${ props => props.attachButtons ? 1 : 0 }rem;
 
   flex-wrap: wrap;
   justify-items: center;

--- a/admin/src/components/ItemFooter/index.js
+++ b/admin/src/components/ItemFooter/index.js
@@ -19,7 +19,7 @@ const ENTITY_NAME_PARAMS = [
 const resolveEntityName = (entity) =>
   ENTITY_NAME_PARAMS.map((_) => entity[_]).filter((_) => _)[0] || "";
 
-const ItemFooter = ({ type, removed, relatedRef }) => {
+const ItemFooter = ({ type, removed, relatedRef, attachButtons }) => {
   const formatRelationType = () =>
     !isNil(relatedRef) ? relatedRef.__contentType : "";
 
@@ -27,7 +27,7 @@ const ItemFooter = ({ type, removed, relatedRef }) => {
     !isNil(relatedRef) ? resolveEntityName(relatedRef) : "";
 
   return (
-    <Wrapper removed={removed}>
+    <Wrapper removed={removed} attachButtons={attachButtons}>
       <CardItemType>
         <FontAwesomeIcon
           icon={type === navigationItemType.EXTERNAL ? faGlobe : faSitemap}
@@ -49,6 +49,7 @@ ItemFooter.propTypes = {
   menuAttached: PropTypes.bool,
   removed: PropTypes.bool,
   relatedRef: PropTypes.object,
+  attachButtons: PropTypes.bool,
 };
 
 export default ItemFooter;

--- a/admin/src/components/ItemOrdering/CardOrderingButton.js
+++ b/admin/src/components/ItemOrdering/CardOrderingButton.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+import { Button } from "@buffetjs/core";
+import { sizes } from "strapi-helper-plugin";
+
+const CardOrderingButton = styled(Button)`
+  display: flex;
+  width: ${ props => props.size }px;
+  height: ${ props => props.size }px;
+  padding: 0;
+  margin-left: ${ sizes.margin / 2 }px;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: ${ props => props.size / 2 }px;
+
+  background: #ffffff;
+
+  svg {
+    margin-right: 0;
+  }
+`;
+
+export default CardOrderingButton;

--- a/admin/src/components/ItemOrdering/Wrapper.js
+++ b/admin/src/components/ItemOrdering/Wrapper.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import CardOrderingButton from "./CardOrderingButton";
+
+const Wrapper = styled.div`
+  display: flex;
+
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: ${ props => -1 * (props.fixBy || 0) }px;
+  z-index: 1;
+
+  ${ CardOrderingButton } {
+    &:first {
+      margin-left: 0;
+    }
+  }
+`;
+
+export default Wrapper;

--- a/admin/src/components/ItemOrdering/index.js
+++ b/admin/src/components/ItemOrdering/index.js
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowUp, faArrowDown } from "@fortawesome/free-solid-svg-icons";
+import Wrapper from "./Wrapper";
+import CardOrderingButton from "./CardOrderingButton";
+import { sizes } from "strapi-helper-plugin";
+
+const BUTTON_SIZE = 2.4 * sizes.margin;
+
+const ItemOrdering = ({ isFirst, isLast, onChangeOrder }) => {
+  return (
+    <Wrapper fixBy={ BUTTON_SIZE / 2 }>
+      { !isFirst && (<CardOrderingButton
+        size={BUTTON_SIZE}
+        color="secondary"
+        icon={<FontAwesomeIcon icon={faArrowUp} size="1x" />}
+        onClick={(e) => onChangeOrder(e, -1)}
+      />) }
+      { !isLast && (<CardOrderingButton
+        size={BUTTON_SIZE}
+        color="secondary"
+        icon={<FontAwesomeIcon icon={faArrowDown} size="1x" />}
+        onClick={(e) => onChangeOrder(e, 1)}
+      />) }
+    </Wrapper>
+  );
+};
+
+ItemOrdering.propTypes = {
+  isFirst: PropTypes.bool,
+  isLast: PropTypes.bool,
+  onChangeOrder: PropTypes.func.isRequired,
+};
+
+export default ItemOrdering;

--- a/admin/src/components/List/index.js
+++ b/admin/src/components/List/index.js
@@ -11,6 +11,7 @@ const List = ({
   root,
   items,
   onItemClick,
+  onItemReOrder,
   onItemRestoreClick,
   onItemLevelAddClick,
   as,
@@ -30,8 +31,11 @@ const List = ({
             relatedRef={relatedRef}
             level={level}
             levelPath={levelPath}
+            isFirst={n === 0}
+            isLast={n === items.length - 1}
             allowedLevels={allowedLevels}
             onItemClick={onItemClick}
+            onItemReOrder={onItemReOrder}
             onItemRestoreClick={onItemRestoreClick}
             onItemLevelAddClick={onItemLevelAddClick}
           />
@@ -58,6 +62,7 @@ List.propTypes = {
   level: PropTypes.number,
   allowedLevels: PropTypes.number,
   onItemClick: PropTypes.func.isRequired,
+  onItemReOrder: PropTypes.func.isRequired,
   onItemRestoreClick: PropTypes.func.isRequired,
   onItemLevelAddClick: PropTypes.func.isRequired,
 };

--- a/admin/src/containers/View/index.js
+++ b/admin/src/containers/View/index.js
@@ -119,6 +119,16 @@ const View = () => {
     });
   };
 
+  const reOrderNavigationItem = (e, item, moveBy = 0) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    handleSubmitNavigationItem({
+      ...item,
+      order: item.order + (moveBy * 1.5),
+    });
+  }
+
   const onPopUpClose = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -182,6 +192,7 @@ const View = () => {
                   <List
                     items={changedActiveNavigation.items || []}
                     onItemClick={editNavigationItem}
+                    onItemReOrder={reOrderNavigationItem}
                     onItemRestoreClick={restoreNavigationItem}
                     onItemLevelAddClick={addNewNavigationItem}
                     root

--- a/models/navigationItem.settings.json
+++ b/models/navigationItem.settings.json
@@ -40,6 +40,11 @@
       "default": false,
       "configurable": false
     },
+    "order": {
+      "type": "integer",
+      "default": 0,
+      "configurable": false
+    },
     "related": {
       "collection": "*",
       "filter": "field",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "Navigation",

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -160,7 +160,10 @@ module.exports = {
 
     const entityItems = await strapi
       .query(itemModel.modelName, pluginName)
-      .find({ master: id }, ["related", "audience"]);
+      .find({ 
+        master: id,
+        _sort: 'order:asc', 
+      }, ["related", "audience"]);
 
     return {
       ...sanitizeEntity(entity,
@@ -232,7 +235,8 @@ module.exports = {
       const items = await strapi.query(itemModel.modelName, pluginName).find(
         {
           master: entity.id,
-          ...itemCriteria,
+          ...itemCriteria, 
+          _sort: 'order:asc',
         },
         ["related", "audience"],
       );


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/4

## Summary

What does this PR do/solve? 

Introduces the items ordering / re-ordering feature to the UI.

## Test Plan

1. Add couple items within the navigation plugin editor
2. Change position of some items
3. Save
4. Reload and see that changes has been saved
