### PR TITLE
feat: fix problem with parsing after remove object in relation

### DIFF
--- a/admin/src/containers/DataManagerProvider/index.js
+++ b/admin/src/containers/DataManagerProvider/index.js
@@ -92,7 +92,8 @@ const DataManagerProvider = ({ children }) => {
         });
       }
     } catch (err) {
-      console.error({ err });
+      // please don't do this, because js stringify a error and that error is not readable in dev tool
+      console.error(err);
       strapi.notification.error("notification.error");
     }
   };

--- a/admin/src/containers/View/utils/parsers.js
+++ b/admin/src/containers/View/utils/parsers.js
@@ -1,5 +1,5 @@
 import { v4, validate as validateUUID } from "uuid";
-import { get, find, first, orderBy, upperFirst, isObject, isString, isNumber, isArray, isNil } from "lodash";
+import { get, find, first, orderBy, upperFirst, isObject, isString, isNumber, isArray, isNil, isEmpty } from 'lodash';
 import { navigationItemType } from "./enums";
 
 export const transformItemToRESTPayload = (
@@ -28,8 +28,8 @@ export const transformItemToRESTPayload = (
   const { contentTypeItems = [], contentTypes = [] } = config;
   const relatedId = isExternal || (isString(related) && validateUUID(related)) ? related : parseInt(related, 10);
   const relatedContentTypeItem = isExternal ? undefined : find(contentTypeItems, cti => cti.id === relatedId);
-  const relatedContentType = relatedContentTypeItem || relatedType ? 
-    find(contentTypes, ct => ct.collectionName === (relatedContentTypeItem ? relatedContentTypeItem.__collectionName : relatedType)) : 
+  const relatedContentType = relatedContentTypeItem || relatedType ?
+    find(contentTypes, ct => ct.collectionName === (relatedContentTypeItem ? relatedContentTypeItem.__collectionName : relatedType)) :
     undefined;
 
   return {
@@ -79,8 +79,9 @@ const linkRelations = (item, config) => {
     relatedRef: undefined,
     relatedType: undefined
   }
-  
-  if ((type !== navigationItemType.INTERNAL) || !related) {
+
+  // we got empty array after remove object in relation
+  if ((type !== navigationItemType.INTERNAL) || !related || isEmpty(related)) {
     return {
       ...item,
       ...relation,
@@ -88,7 +89,7 @@ const linkRelations = (item, config) => {
   }
 
   const relatedItem = isArray(related) ? first(related) : related;
-  const relatedId = isString(related) && !validateUUID(related) ? parseInt(related, 10) : related; 
+  const relatedId = isString(related) && !validateUUID(related) ? parseInt(related, 10) : related;
   const relationNotChanged = relatedRef && relatedItem ? relatedRef.id === relatedItem : false;
 
   if (relationNotChanged) {
@@ -102,7 +103,7 @@ const linkRelations = (item, config) => {
     const __collectionName = get(find(contentTypes, ct => ct.name.toLowerCase() === __contentType.toLowerCase()), 'collectionName');
     relation = {
       related: relatedItem.id,
-      relatedRef: { 
+      relatedRef: {
         __collectionName,
         ...relatedItem
       },
@@ -130,7 +131,7 @@ const linkRelations = (item, config) => {
   };
 };
 
-const reOrderItems = (items = []) => 
+const reOrderItems = (items = []) =>
   orderBy(items, ['order'], ['asc'])
     .map((item, n) => {
       const order = n + 1;
@@ -206,7 +207,7 @@ export const transformItemToViewPayload = (payload, items = [], config) => {
     return reOrderItems(updatedLevel);
 };
 
-export const prepareItemToViewPayload = (items = [], viewParentId = null, config = {}) => 
+export const prepareItemToViewPayload = (items = [], viewParentId = null, config = {}) =>
   items.map((item, n) => {
     const viewId = v4();
     return {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/-<your-ticket-#>

## Summary

That PR will fix the problem with init components after the situation when we remove object in relation example:
1. Add an object to a relation
2. Add navigation and assign an object to the navigation item
3. remove object in relation
4. navigation not loaded correctly.

## Test Plan

How are you testing the work you're submitting?
