### PR TITLE
feat: preventing stop assign relation on edit

### DIFF
--- a/admin/src/containers/View/components/NavigationItemForm/index.js
+++ b/admin/src/containers/View/components/NavigationItemForm/index.js
@@ -111,7 +111,7 @@ const NavigationItemForm = ({
   const relatedSelectValue = get(form, "related", undefined);
   const relatedSelectOptions = contentTypeEntities
     .filter((item) => !find(usedContentTypeEntities.filter(uctItem => uctItem.id !== get(relatedSelectValue, 'value')), uctItem =>
-        (get(relatedTypeSelectValue, 'value') === uctItem.__collectionName) && (item.id === uctItem.id) 
+        (get(relatedTypeSelectValue, 'value') === uctItem.__collectionName) && (item.id === uctItem.id)
       ))
     .map((item) => ({
       value: item.id,
@@ -342,7 +342,6 @@ NavigationItemForm.propTypes = {
   formErrors: PropTypes.object.isRequired,
   inputsPrefix: PropTypes.string,
   data: PropTypes.object.isRequired,
-  onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func,
   requestError: PropTypes.object,
   contentTypes: PropTypes.array,

--- a/admin/src/containers/View/utils/parsers.js
+++ b/admin/src/containers/View/utils/parsers.js
@@ -81,7 +81,8 @@ const linkRelations = (item, config) => {
   }
 
   // we got empty array after remove object in relation
-  if ((type !== navigationItemType.INTERNAL) || !related || isEmpty(related)) {
+  // from API we got related as array but on edit it is primitive type
+  if ((type !== navigationItemType.INTERNAL) || !related || (isObject(related) && isEmpty(related))) {
     return {
       ...item,
       ...relation,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/-<your-ticket-#>

## Summary

`admin/src/containers/View/components/NavigationItemForm/index.js`
onChange is not used in component

`admin/src/containers/View/utils/parsers.js`
as in comment in the file here, we have some inconsistent data on fetch we got array but on edit, we get primitive type where is `isEmpty` returning true

## Test Plan

How are you testing the work you're submitting?
