### PR TITLE
fix: styling audit log example

### DIFF
--- a/examples/audit-log-integrations.js.md
+++ b/examples/audit-log-integrations.js.md
@@ -1,3 +1,4 @@
+```javascript
 const { Base, AvailableAction } = require('strapi-plugin-audit-log');
 
 class Navigation extends Base {
@@ -34,3 +35,4 @@ class Navigation extends Base {
 }
 
 module.exports = Navigation;
+```


### PR DESCRIPTION
## Ticket

make audit log example readable on GH
now: https://github.com/VirtusLab/strapi-plugin-navigation/blob/master/examples/audit-log-integrations.js.md
after merge this PR: https://github.com/VirtusLab/strapi-plugin-navigation/blob/fix/styling-audit-log-example/examples/audit-log-integrations.js.md
