### PR TITLE
Feature: Automatically filter content types with relation to navigati…

### DIFF
--- a/__mocks__/helpers/strapi.js
+++ b/__mocks__/helpers/strapi.js
@@ -16,10 +16,12 @@ function setupStrapi() {
             'page': {
                 ...require('./page.settings.json'),
                 apiName: 'pages',
+                associations: [{ model: 'navigationitem' }],
             },
             'blog-post': {
                 ...require('./blog-post.settings.json'),
                 apiName: 'blog-posts',
+                associations: [{ model: 'navigationitem' }],
             },
           },
           plugins: {

--- a/services/__tests__/navigation.test.js
+++ b/services/__tests__/navigation.test.js
@@ -32,7 +32,8 @@ describe('Navigation service', () => {
           name: "blog-post",
           visible: true,
       }];
-      expect(configContentTypes()[0]).toMatchObject(result[0]);
-      expect(configContentTypes()[1]).toMatchObject(result[1]);
+      const types = configContentTypes();
+      expect(types[0]).toMatchObject(result[0]);
+      expect(types[1]).toMatchObject(result[1]);
     });
 });

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -29,17 +29,6 @@ const navigationItem = require('../models/navigationItem');
  * @description: A set of functions similar to controller's actions to avoid code duplication.
  */
 
-
-
-const excludedContentTypes = get(
-  strapi.config,
-  "custom.plugins.navigation.excludedContentTypes",
-  [
-    "plugins::",
-    "strapi",
-  ],
-);
-
 const contentTypesNameFieldsDefaults = [
   "title",
   "subject",
@@ -87,9 +76,10 @@ module.exports = {
   configContentTypes: () =>
     Object.keys(strapi.contentTypes)
       .filter(
-        (key) =>
-          excludedContentTypes.filter((ect) => key.includes(ect)).length ===
-          0,
+        (key) => {
+          const item = strapi.contentTypes[key];
+          return (item.associations || []).some(_ => _.model === 'navigationitem');
+        },
       )
       .map((key) => {
         const item = strapi.contentTypes[key];


### PR DESCRIPTION
…on items



## Summary
Solved problem with manual config witch content type can be displayed in related dropdown.

> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs

## Test Plan

1. Create a new content type
2. Without config shouldn't display in related dropdown
3. Add relation in the model
4. Should display in the related dropdown.

How are you testing the work you're submitting?
