### PR TITLE
fix: use uid instead of collection name for linking

### DIFF
--- a/__mocks__/helpers/blog-post.settings.json
+++ b/__mocks__/helpers/blog-post.settings.json
@@ -3,7 +3,7 @@
   "kind": "collectionType",
   "collectionName": "blog_posts",
   "info": {
-    "name": "Blog posts"
+    "name": "Blog post"
   },
   "options": {
     "increments": true,

--- a/__mocks__/helpers/pages.settings.json
+++ b/__mocks__/helpers/pages.settings.json
@@ -1,9 +1,9 @@
 {
-  "uid": "application::page.page",
+  "uid": "application::pages.pages",
   "kind": "collectionType",
   "collectionName": "pages",
   "info": {
-    "name": "page"
+    "name": "pages"
   },
   "options": {
     "increments": true,

--- a/__mocks__/helpers/strapi.js
+++ b/__mocks__/helpers/strapi.js
@@ -14,7 +14,7 @@ function setupStrapi() {
           },
           contentTypes: {
             'page': {
-                ...require('./page.settings.json'),
+                ...require('./pages.settings.json'),
                 apiName: 'pages',
                 associations: [{ model: 'navigationitem' }],
             },
@@ -30,7 +30,7 @@ function setupStrapi() {
                       navigation: jest.fn().mockImplementation(),
                   },
                   models: {
-                      'page': require('./page.settings.json'),
+                      'pages': require('./pages.settings.json'),
                       'blog-post': require('./blog-post.settings.json'),
                   }
               }

--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -28,6 +28,7 @@ const Item = (props) => {
     relatedRef,
     isFirst = false,
     isLast = false,
+    isParentAttachedToMenu,
     onItemClick,
     onItemReOrder,
     onItemRestoreClick,
@@ -79,6 +80,7 @@ const Item = (props) => {
           removed ? null : onItemClick(e, {
             ...item,
             isMenuAllowedLevel,
+            isParentAttachedToMenu,
           }, levelPath)
         }
       >
@@ -106,7 +108,7 @@ const Item = (props) => {
         <CardItemLevelAdd
           color={isNextMenuAllowedLevel ? 'primary' : 'secondary'}
           icon={<FontAwesomeIcon icon={faPlus} size="3x" />}
-          onClick={(e) => onItemLevelAddClick(e, viewId, isNextMenuAllowedLevel, levelPath)}
+          onClick={(e) => onItemLevelAddClick(e, viewId, isNextMenuAllowedLevel, levelPath, menuAttached)}
           menuLevel={isNextMenuAllowedLevel}
         />
       )}
@@ -121,6 +123,7 @@ const Item = (props) => {
           level={level + 1}
           levelPath={absolutePath}
           allowedLevels={allowedLevels}
+          isParentAttachedToMenu={menuAttached}
           contentTypesNameFields={contentTypesNameFields}
           error={error}
         />
@@ -146,6 +149,7 @@ Item.propTypes = {
   levelPath: PropTypes.string,
   isFirst: PropTypes.bool,
   isLast: PropTypes.bool,
+  isParentAttachedToMenu: PropTypes.bool,
   onItemClick: PropTypes.func.isRequired,
   onItemRestoreClick: PropTypes.func.isRequired,
   onItemLevelAddClick: PropTypes.func.isRequired,

--- a/admin/src/components/List/index.js
+++ b/admin/src/components/List/index.js
@@ -18,6 +18,7 @@ const List = ({
   level = 0,
   levelPath = '',
   allowedLevels,
+  isParentAttachedToMenu = false,
   contentTypesNameFields,
   error,
 }) => {
@@ -35,6 +36,7 @@ const List = ({
             levelPath={levelPath}
             isFirst={n === 0}
             isLast={n === items.length - 1}
+            isParentAttachedToMenu={isParentAttachedToMenu}
             allowedLevels={allowedLevels}
             contentTypesNameFields={contentTypesNameFields}
             onItemClick={onItemClick}
@@ -52,7 +54,7 @@ const List = ({
             menuLevel
             color="primary"
             icon={<FontAwesomeIcon icon={faPlus} />}
-            onClick={e => onItemLevelAddClick(e, null, true, levelPath)}
+            onClick={e => onItemLevelAddClick(e, null, true, levelPath, true)}
           />
         </ListLevelRoot>
       )}
@@ -65,6 +67,7 @@ List.propTypes = {
   items: PropTypes.array,
   level: PropTypes.number,
   allowedLevels: PropTypes.number,
+  isParentAttachedToMenu: PropTypes.bool,
   contentTypesNameFields: PropTypes.object.isRequired,
   onItemClick: PropTypes.func.isRequired,
   onItemReOrder: PropTypes.func.isRequired,

--- a/admin/src/containers/View/components/NavigationItemPopup/index.js
+++ b/admin/src/containers/View/components/NavigationItemPopup/index.js
@@ -38,6 +38,7 @@ const NavigationItemPopUp = ({
     contentTypesNameFields = {},
   } = config;
 
+  const relatedTypeItem = find(contentTypes, item => item.uid === relatedType, {});
   const prepareFormData = data => ({
     ...data,
     related: related ? {
@@ -45,11 +46,11 @@ const NavigationItemPopUp = ({
       label: extractRelatedItemLabel({
         ...find(contentTypeItems, item => item.id === related, {}),
         __collectionName: relatedType,
-      }, contentTypesNameFields),
+      }, contentTypesNameFields, config),
     } : undefined,
     relatedType: relatedType ? {
       value: relatedType,
-      label: find(contentTypes, item => item.collectionName === relatedType, {}).label,
+      label: relatedTypeItem.label || relatedTypeItem.name,
     } : undefined,
   });
 

--- a/admin/src/containers/View/index.js
+++ b/admin/src/containers/View/index.js
@@ -32,12 +32,10 @@ const View = () => {
     activeItem: activeNavigation,
     changedActiveItem: changedActiveNavigation,
     config,
-    navigationPopupOpened,
     navigationItemPopupOpened,
     isLoading,
     isLoadingForAdditionalDataToBeSet,
     isLoadingForSubmit,
-    handleChangeNavigationPopupVisibility,
     handleChangeNavigationItemPopupVisibility,
     handleChangeSelection,
     handleChangeNavigationData,
@@ -78,7 +76,7 @@ const View = () => {
           __collectionName: curr.relatedRef.__collectionName,
           id: curr.relatedRef.id
         } : undefined, ...pullUsedContentTypeItem(curr.items)].filter(item => item)
-      , [])
+      , []);
   const usedContentTypeItems = pullUsedContentTypeItem((changedActiveNavigation || {}).items);
 
   const changeNavigationItemPopupState = (visible, editedItem = {}) => {
@@ -91,6 +89,7 @@ const View = () => {
     viewId = null,
     isMenuAllowedLevel = true,
     levelPath = '',
+    parentAttachedToMenu = true,
   ) => {
     e.preventDefault();
     e.stopPropagation();
@@ -98,15 +97,22 @@ const View = () => {
       viewParentId: viewId,
       isMenuAllowedLevel,
       levelPath,
+      parentAttachedToMenu,
     });
   };
 
-  const editNavigationItem = (e, item, levelPath = '') => {
+  const editNavigationItem = (
+    e,
+    item,
+    levelPath = '',
+    parentAttachedToMenu = true,
+  ) => {
     e.preventDefault();
     e.stopPropagation();
     changeNavigationItemPopupState(true, {
       ...item,
       levelPath,
+      parentAttachedToMenu,
     });
   };
 
@@ -204,6 +210,7 @@ const View = () => {
                     root
                     error={error}
                     allowedLevels={config.allowedLevels}
+                    isParentAttachedToMenu={true}
                     contentTypesNameFields={config.contentTypesNameFields}
                   />
                 )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "Navigation",

--- a/services/__tests__/navigation.test.js
+++ b/services/__tests__/navigation.test.js
@@ -12,10 +12,10 @@ describe('Navigation service', () => {
   it('Config Content Types', () => {
       const { configContentTypes } = require("../navigation");
       const result = [{
-          uid: "application::page.page",
+          uid: "application::pages.pages",
           collectionName: "pages",
           isSingle: false,
-          contentTypeName: "Page",
+          contentTypeName: "Pages",
           endpoint: "pages",
           label: "Pages",
           labelSingular: "Page",

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -89,9 +89,9 @@ module.exports = {
         const { isManaged, hidden } = options;
         const isSingle = kind === KIND_TYPES.SINGLE;
         const endpoint = isSingle ? apiName : pluralize(apiName);
-        const relationName = last(apiName) === 's' ? apiName.substr(0, apiName.length - 1) : apiName;
-        const relationNameParts = relationName.split('-');
-        const contentTypeName = relationNameParts.length > 1 ? relationNameParts.reduce((prev, curr) => `${prev}${upperFirst(curr)}`, '') : upperFirst(relationName);
+        const relationName = utilsFunctions.singularize(apiName);
+        const relationNameParts = last(uid.split('.')).split('-');
+        const contentTypeName = relationNameParts.length > 1 ? relationNameParts.reduce((prev, curr) => `${prev}${upperFirst(curr)}`, '') : upperFirst(apiName);
         const labelSingular = upperFirst(relationNameParts.length > 1 ? relationNameParts.join(' ') : relationName);
         return {
           uid,
@@ -102,7 +102,7 @@ module.exports = {
           contentTypeName,
           label: isSingle ? labelSingular : pluralize(labelSingular || name),
           relatedField: relatedField ? relatedField.alias : undefined,
-          labelSingular,
+          labelSingular: utilsFunctions.singularize(labelSingular),
           endpoint,
           plugin,
           visible: (isManaged || isNil(isManaged)) && !hidden,

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -31,6 +31,10 @@ module.exports = {
         };
       },
 
+    singularize(value = '') {
+      return last(value) === 's' ? value.substr(0, value.length - 1) : value;
+    },
+
     checkDuplicatePath(parentItem, checkData) {
         return new Promise((resolve, reject) => {
           if (parentItem && parentItem.items) {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/28
https://github.com/VirtusLab/strapi-plugin-navigation/issues/35

## Summary

What does this PR do/solve? 

- changes the way if relations linking
- fixing the associations mismatch between SQL and noSQL databases

## Test Plan

- run on any SQL database
- run on MondoDB
- see that all works
