### PR TITLE
fix: providing coverage for draft and publish Strapi content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Complete installation requirements are exact same as for Strapi itself and can b
 
 **Supported Strapi versions**:
 
-- Strapi v3.5.0 (recently tested)
+- Strapi v3.5.2 (recently tested)
 - Strapi v3.x
 
 (This plugin may work with the older Strapi versions, but these are not tested nor officially supported at this time.)
@@ -109,7 +109,6 @@ To setup the plugin properly we recommend to put following snippet as part of `c
     plugins: {
       navigation: {
         additionalFields: ['audience'],
-        excludedContentTypes: ["plugins::", "strapi"],
         allowedLevels: 2,
         contentTypesNameFields: {
           'blog_posts': ['altTitle'],
@@ -122,7 +121,6 @@ To setup the plugin properly we recommend to put following snippet as part of `c
 
 ### Properties
 - `additionalFields` - Additional fields: 'audience', more in the future
-- `excludedContentTypes` - Excluded content types patterns (by default built-in and plugin specific content types)
 - `allowedLevels` - Maximum level for which your're able to mark item as "Menu attached"
 - `contentTypesNameFields` - Definition of content type title fields like `'content_type_name': ['field_name_1', 'field_name_2']`, if not set titles are pulled from fields like `['title', 'subject', 'name']`
 
@@ -369,7 +367,17 @@ If you would like to use the [Strapi Molecules Audit Log](https://github.com/Vir
 ```
 As a last step you've to provide the Navigation class to let Audit Log use it. To not provide external & hard dependencies we've added the example of class code in the `examples/audit-log-integration.js` .
 
+## Examples
 
+Live example of plugin usage can be found in the [VirtusLab Strapi Examples](https://github.com/VirtusLab/strapi-examples/tree/master/strapi-plugin-navigation) repository.
+
+## Q&A
+
+### Content Types
+
+**Q:** I've recognized **Navigation Item** and **Navigation** collection types in the Collections sidebar section, but they are not working properly. What should I do?
+
+**A:** As an authors of the plugin we're not supporting any editing of mentioned content types via built-in Strapi Content Manager. Plugin delivers highly customized & extended functionality which might be covered only by dedicated editor UI accessible via **Plugins Section > UI Navigation**. Only issues that has been recognized there, are in the scope of support we've providing.
 
 ## Contributing
 

--- a/__mocks__/helpers/pages.settings.json
+++ b/__mocks__/helpers/pages.settings.json
@@ -3,7 +3,7 @@
   "kind": "collectionType",
   "collectionName": "pages",
   "info": {
-    "name": "pages"
+    "name": "Pages"
   },
   "options": {
     "increments": true,

--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -25,6 +25,7 @@ const Item = (props) => {
     levelPath = '',
     allowedLevels,
     contentTypesNameFields,
+    contentTypes,
     relatedRef,
     isFirst = false,
     isLast = false,
@@ -40,15 +41,18 @@ const Item = (props) => {
     title,
     type,
     path,
+    relatedType,
     removed,
     externalPath,
     menuAttached,
   } = item;
   const footerProps = {
+    contentTypes,
     type: type || navigationItemType.INTERNAL,
     removed,
     menuAttached,
     relatedRef,
+    relatedType,
     contentTypesNameFields,
     attachButtons: !(isFirst && isLast),
   };
@@ -125,6 +129,7 @@ const Item = (props) => {
           allowedLevels={allowedLevels}
           isParentAttachedToMenu={menuAttached}
           contentTypesNameFields={contentTypesNameFields}
+          contentTypes={contentTypes}
           error={error}
         />
       )}
@@ -144,6 +149,7 @@ Item.propTypes = {
     menuAttached: PropTypes.bool,
   }).isRequired,
   relatedRef: PropTypes.object,
+  contentTypes: PropTypes.array,
   contentTypesNameFields: PropTypes.object.isRequired,
   level: PropTypes.number,
   levelPath: PropTypes.string,

--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -15,8 +15,8 @@ import CardItemLevelAdd from './CardItemLevelAdd';
 import List from '../List';
 import CardItemLevelWrapper from './CardItemLevelWrapper';
 import CardItemRestore from './CardItemRestore';
-import pluginId from '../../pluginId';
 import ItemOrdering from '../ItemOrdering';
+import { getTrad } from '../../translations';
 
 const Item = (props) => {
   const {
@@ -92,9 +92,7 @@ const Item = (props) => {
           <Button
             onClick={e => onItemRestoreClick(e, item)}
             color="secondary"
-            label={formatMessage({
-              id: `${pluginId}.popup.item.form.button.restore`,
-            })}
+            label={formatMessage(getTrad('popup.item.form.button.restore'))}
           />
         </CardItemRestore>)}
         <CardItemTitle>{title}</CardItemTitle>

--- a/admin/src/components/ItemFooter/CardItemError.js
+++ b/admin/src/components/ItemFooter/CardItemError.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+import { sizes } from "strapi-helper-plugin";
+import CardItemRelation from "./CardItemRelation";
+
+const CardItemError = styled(CardItemRelation)`
+  color: red;
+  font-weight: bold;
+`;
+
+export default CardItemError;

--- a/admin/src/components/ItemFooter/CardItemRelationStatus.js
+++ b/admin/src/components/ItemFooter/CardItemRelationStatus.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+import { colors, sizes } from "strapi-helper-plugin";
+
+const CardItemRelationStatus = styled.small`
+  display: inline-block;
+  padding: ${`${sizes.margin * .1}px ${sizes.margin * .5}px`};
+  margin-left: ${`${sizes.margin / 2}px`};
+  
+  color: #ffffff;
+  font-weight: bold;
+
+  background: orange;
+  border-radius: ${`${sizes.margin * .3}px`};
+`;
+
+export default CardItemRelationStatus;

--- a/admin/src/components/ItemFooter/index.js
+++ b/admin/src/components/ItemFooter/index.js
@@ -1,22 +1,32 @@
 import React from 'react';
+import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faLink, faGlobe, faSitemap } from '@fortawesome/free-solid-svg-icons';
+import { faLink, faGlobe, faSitemap, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import CardItemRelation from './CardItemRelation';
 import CardItemType from './CardItemType';
 import Wrapper from './Wrapper';
-import { isNil, get, upperFirst } from 'lodash';
+import { isNil, get, find, upperFirst } from 'lodash';
+import pluginId from '../../pluginId';
 import { navigationItemType } from '../../containers/View/utils/enums';
-import { extractRelatedItemLabel } from '../../containers/View/utils/parsers';
+import { extractRelatedItemLabel, isRelationCorrect, isRelationPublished } from '../../containers/View/utils/parsers';
+import CardItemError from './CardItemError';
+import CardItemRelationStatus from './CardItemRelationStatus';
 
-const ItemFooter = ({ type, removed, relatedRef, attachButtons, contentTypesNameFields }) => {
+const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, contentTypesNameFields, contentTypes }) => {
+  const { formatMessage } = useIntl();
+
+  const isRelationDefined = !isNil(relatedRef);
+
+
   const formatRelationType = () =>
-    !isNil(relatedRef) ? get(relatedRef, 'labelSingular', get(relatedRef, '__contentType')) : '';
+  isRelationDefined ? get(relatedRef, 'labelSingular', get(relatedRef, '__contentType')) : '';
 
   const formatRelationName = () =>
-    !isNil(relatedRef) ? extractRelatedItemLabel(relatedRef, contentTypesNameFields) : '';
+  isRelationDefined ? extractRelatedItemLabel(relatedRef, contentTypesNameFields) : '';
 
   const isSingle = get(relatedRef, 'isSingle', false);
+  const relatedContentType = isRelationDefined && isSingle ? find(contentTypes, cnt => cnt.uid === relatedType) : undefined;
 
   return (
     <Wrapper removed={removed} attachButtons={attachButtons}>
@@ -26,11 +36,26 @@ const ItemFooter = ({ type, removed, relatedRef, attachButtons, contentTypesName
         />{' '}
         {upperFirst(type.toLowerCase())}
       </CardItemType>
-      {!isNil(relatedRef) && (
+      {isRelationCorrect({ type, related: relatedRef }) && (
         <CardItemRelation title={formatRelationName()}>
           <FontAwesomeIcon icon={faLink} />{' '}
           {isSingle ? formatRelationType() : `(${formatRelationType()}) ${formatRelationName()}`}
+          { !isRelationPublished({ relatedRef, relatedType: relatedContentType, type, isCollection: !isNil(relatedContentType) }) && (
+          <CardItemRelationStatus>
+            { `${formatMessage({
+              id: `${pluginId}.notification.navigation.item.relation.status.draft`,
+            })}` }
+          </CardItemRelationStatus>
+          ) }
         </CardItemRelation>
+      )}
+      { !isRelationCorrect({ type, related: relatedRef }) && (
+        <CardItemError title={formatRelationName()}>
+          <FontAwesomeIcon icon={faExclamationTriangle} />{' '}
+          { formatMessage({
+              id: `${pluginId}.notification.navigation.item.relation`,
+            }) }
+        </CardItemError>
       )}
     </Wrapper>
   );

--- a/admin/src/components/ItemFooter/index.js
+++ b/admin/src/components/ItemFooter/index.js
@@ -7,11 +7,11 @@ import CardItemRelation from './CardItemRelation';
 import CardItemType from './CardItemType';
 import Wrapper from './Wrapper';
 import { isNil, get, find, upperFirst } from 'lodash';
-import pluginId from '../../pluginId';
 import { navigationItemType } from '../../containers/View/utils/enums';
 import { extractRelatedItemLabel, isRelationCorrect, isRelationPublished } from '../../containers/View/utils/parsers';
 import CardItemError from './CardItemError';
 import CardItemRelationStatus from './CardItemRelationStatus';
+import { getTrad } from '../../translations';
 
 const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, contentTypesNameFields, contentTypes }) => {
   const { formatMessage } = useIntl();
@@ -42,9 +42,7 @@ const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, con
           {isSingle ? formatRelationType() : `(${formatRelationType()}) ${formatRelationName()}`}
           { !isRelationPublished({ relatedRef, relatedType: relatedContentType, type, isCollection: !isNil(relatedContentType) }) && (
           <CardItemRelationStatus>
-            { `${formatMessage({
-              id: `${pluginId}.notification.navigation.item.relation.status.draft`,
-            })}` }
+            { `${formatMessage(getTrad('notification.navigation.item.relation.status.draft'))}` }
           </CardItemRelationStatus>
           ) }
         </CardItemRelation>
@@ -52,9 +50,7 @@ const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, con
       { !isRelationCorrect({ type, related: relatedRef }) && (
         <CardItemError title={formatRelationName()}>
           <FontAwesomeIcon icon={faExclamationTriangle} />{' '}
-          { formatMessage({
-              id: `${pluginId}.notification.navigation.item.relation`,
-            }) }
+          { formatMessage(getTrad('notification.navigation.item.relation')) }
         </CardItemError>
       )}
     </Wrapper>

--- a/admin/src/components/ItemFooter/index.js
+++ b/admin/src/components/ItemFooter/index.js
@@ -18,7 +18,6 @@ const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, con
 
   const isRelationDefined = !isNil(relatedRef);
 
-
   const formatRelationType = () =>
   isRelationDefined ? get(relatedRef, 'labelSingular', get(relatedRef, '__contentType')) : '';
 
@@ -26,6 +25,7 @@ const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, con
   isRelationDefined ? extractRelatedItemLabel(relatedRef, contentTypesNameFields) : '';
 
   const isSingle = get(relatedRef, 'isSingle', false);
+  const isExternal = type === navigationItemType.EXTERNAL;
   const relatedContentType = isRelationDefined && isSingle ? find(contentTypes, cnt => cnt.uid === relatedType) : undefined;
 
   return (
@@ -36,7 +36,7 @@ const ItemFooter = ({ type, removed, relatedRef, relatedType, attachButtons, con
         />{' '}
         {upperFirst(type.toLowerCase())}
       </CardItemType>
-      {isRelationCorrect({ type, related: relatedRef }) && (
+      {isRelationCorrect({ type, related: relatedRef }) && !isExternal && (
         <CardItemRelation title={formatRelationName()}>
           <FontAwesomeIcon icon={faLink} />{' '}
           {isSingle ? formatRelationType() : `(${formatRelationType()}) ${formatRelationName()}`}

--- a/admin/src/components/List/index.js
+++ b/admin/src/components/List/index.js
@@ -19,6 +19,7 @@ const List = ({
   levelPath = '',
   allowedLevels,
   isParentAttachedToMenu = false,
+  contentTypes,
   contentTypesNameFields,
   error,
 }) => {
@@ -43,6 +44,7 @@ const List = ({
             onItemReOrder={onItemReOrder}
             onItemRestoreClick={onItemRestoreClick}
             onItemLevelAddClick={onItemLevelAddClick}
+            contentTypes={contentTypes}
             error={error}
           />
         );
@@ -68,6 +70,7 @@ List.propTypes = {
   level: PropTypes.number,
   allowedLevels: PropTypes.number,
   isParentAttachedToMenu: PropTypes.bool,
+  contentTypes: PropTypes.array,
   contentTypesNameFields: PropTypes.object.isRequired,
   onItemClick: PropTypes.func.isRequired,
   onItemReOrder: PropTypes.func.isRequired,

--- a/admin/src/containers/DataManagerProvider/index.js
+++ b/admin/src/containers/DataManagerProvider/index.js
@@ -165,7 +165,7 @@ const DataManagerProvider = ({ children }) => {
       type: GET_CONTENT_TYPE_ITEMS,
     });
     const url = plugin ? `/${plugin}/${type}` : `/${type}`;
-    const contentTypeItems = await request(url, {
+    const contentTypeItems = await request(`${url}?_publicationState=preview`, {
       method: "GET",
       signal,
     });
@@ -239,7 +239,10 @@ const DataManagerProvider = ({ children }) => {
 
       dispatch({
         type: SUBMIT_NAVIGATION_SUCCEEDED,
-        navigation,
+        navigation: {
+          ...navigation,
+          items: prepareItemToViewPayload(navigation.items, null, config),
+        },
       });
       emitEvent("didSubmitNavigation");
 

--- a/admin/src/containers/DataManagerProvider/index.js
+++ b/admin/src/containers/DataManagerProvider/index.js
@@ -30,6 +30,7 @@ import {
   SUBMIT_NAVIGATION_ERROR,
 } from './actions';
 import { prepareItemToViewPayload } from '../View/utils/parsers';
+import { getTradId } from "../../translations";
 
 const DataManagerProvider = ({ children }) => {
   const [reducerState, dispatch] = useReducer(reducer, initialState, init);
@@ -246,7 +247,7 @@ const DataManagerProvider = ({ children }) => {
       });
       emitEvent("didSubmitNavigation");
 
-      strapi.notification.success(`${pluginId}.notification.navigation.submit`);
+      strapi.notification.success(getTradId('notification.navigation.submit'));
     } catch (err) {
       dispatch({
         type: SUBMIT_NAVIGATION_ERROR,
@@ -257,7 +258,7 @@ const DataManagerProvider = ({ children }) => {
       if (err.response.payload.data && err.response.payload.data.errorTitles) {
         return strapi.notification.error(
           formatMessage(
-            { id: `${pluginId}.notification.navigation.error` },
+            getTrad('notification.navigation.error'),
             { ...err.response.payload.data, errorTitles: err.response.payload.data.errorTitles.join(' and ') },
           ),
         );

--- a/admin/src/containers/DataManagerProvider/reducer.js
+++ b/admin/src/containers/DataManagerProvider/reducer.js
@@ -112,10 +112,14 @@ const reducer = (state, action) => {
         .update('error', () => undefined);
     }
     case SUBMIT_NAVIGATION_SUCCEEDED: {
-      return state.update(
-        'isLoadingForSubmit',
-        () => false,
-      );
+      const { navigation = {} } = action;
+      return state
+        .update("activeItem", () => fromJS(navigation))
+        .update("changedActiveItem", () => fromJS(navigation))
+        .update(
+          'isLoadingForSubmit',
+          () => false,
+        );
     }
     case SUBMIT_NAVIGATION_ERROR: {
       return state

--- a/admin/src/containers/DetailsView/index.js
+++ b/admin/src/containers/DetailsView/index.js
@@ -19,6 +19,7 @@ import CardWrapper from "../../components/ItemDetails/CardWrapper";
 import CardLevelWrapper from "../../components/ItemDetails/CardLevelWrapper";
 import EmptyView from "../../components/EmptyView";
 import { isNil } from "lodash";
+import { getTrad, getTradId } from "../../translations";
 
 const DetailsView = () => {
   const {
@@ -73,17 +74,15 @@ const DetailsView = () => {
     <Wrapper className="col-md-8">
       <Header
         title={{
-          label: formatMessage({ id: `${pluginId}.moderation.header.title` }),
+          label: formatMessage(getTrad('moderation.header.title')),
         }}
-        content={formatMessage({
-          id: `${pluginId}.moderation.header.description`,
-        })}
+        content={formatMessage(getTrad('moderation.header.description'))}
       />
       {isLoadingForDetailsDataToBeSet && <LoadingIndicatorPage />}
       {!isLoadingForDetailsDataToBeSet && !activeItem && (
         <EmptyView fixPosition>
           <FontAwesomeIcon icon={faComments} size="5x" />
-          <FormattedMessage id={`${pluginId}.moderation.content.empty`} />
+          <FormattedMessage id={getTradId('moderation.content.empty')} />
         </EmptyView>
       )}
       {activeItem && (

--- a/admin/src/containers/ListView/index.js
+++ b/admin/src/containers/ListView/index.js
@@ -17,7 +17,7 @@ import Wrapper from "../View/Wrapper";
 import FadedWrapper from "../View/FadedWrapper";
 import List from "../../components/List";
 import EmptyView from "../../components/EmptyView";
-import pluginId from "../../pluginId";
+import { getTrad, getTradId } from "../../translations";
 
 const ListView = () => {
   const { items, isLoadingForDataToBeSet } = useDataManager();
@@ -29,10 +29,10 @@ const ListView = () => {
     <Wrapper className="col-md-4">
       <Header
         title={{
-          label: formatMessage({ id: `${pluginId}.list.header.title` }),
+          label: formatMessage(getTrad('list.header.title')),
         }}
         content={formatMessage(
-          { id: `${pluginId}.list.header.description` },
+          getTrad('list.header.description'),
           { count: newItemsCount },
         )}
       />
@@ -41,7 +41,7 @@ const ListView = () => {
         {isEmpty(items) && (
           <EmptyView>
             <FontAwesomeIcon icon={faSearch} size="5x" />
-            <FormattedMessage id={`${pluginId}.list.content.empty`} />
+            <FormattedMessage id={getTradId('list.content.empty')} />
           </EmptyView>
         )}
         {!isEmpty(items) && <List items={[...items]} />}

--- a/admin/src/containers/View/components/NavigationItemForm/index.js
+++ b/admin/src/containers/View/components/NavigationItemForm/index.js
@@ -29,6 +29,7 @@ const NavigationItemForm = ({
   onSubmit,
   getContentTypeEntities,
   usedContentTypesData,
+  appendLabelPublicationStatus = () => '',
 }) => {
   const [hasBeenInitialized, setInitializedState] = useState(false);
   const [hasChanged, setChangedState] = useState(false);
@@ -141,7 +142,7 @@ const NavigationItemForm = ({
     })
       .map((item) => ({
         value: get(item, 'uid'),
-        label: get(item, 'label', get(item, 'name')),
+        label: appendLabelPublicationStatus(get(item, 'label', get(item, 'name')), item, true),
       })),
     [contentTypes, usedContentTypesData],
   );
@@ -154,10 +155,13 @@ const NavigationItemForm = ({
     })
     .map((item) => ({
       value: item.id,
-      label: extractRelatedItemLabel({
-        ...item,
-        __collectionName: get(relatedTypeSelectValue, 'value', relatedTypeSelectValue),
-      }, contentTypesNameFields, { contentTypes }),
+      label: appendLabelPublicationStatus(
+          extractRelatedItemLabel({
+          ...item,
+          __collectionName: get(relatedTypeSelectValue, 'value', relatedTypeSelectValue),
+        }, contentTypesNameFields, { contentTypes }), 
+        item
+      ),
     }));
 
   const isExternal = form.type === navigationItemType.EXTERNAL;
@@ -404,6 +408,7 @@ NavigationItemForm.propTypes = {
   availableAudience: PropTypes.array,
   additionalFields: PropTypes.array,
   getContentTypeEntities: PropTypes.func.isRequired,
+  appendLabelPublicationStatus: PropTypes.func,
 };
 
 export default NavigationItemForm;

--- a/admin/src/containers/View/components/NavigationItemForm/index.js
+++ b/admin/src/containers/View/components/NavigationItemForm/index.js
@@ -8,13 +8,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEye, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import ModalFooter from './ModalFooter';
 import Input from '../../../../components/Input';
-import pluginId from '../../../../pluginId';
 import { navigationItemAdditionalFields, navigationItemType } from '../../utils/enums';
 import slugify from 'slugify';
 import Select from '../../../../components/Select';
 import { extractRelatedItemLabel } from '../../utils/parsers';
 import { form as formDefinition } from './utils/form';
 import { checkFormValidity } from '../../utils/form';
+import { getTrad, getTradId } from '../../../../translations';
 
 const NavigationItemForm = ({
   isLoading,
@@ -120,9 +120,7 @@ const NavigationItemForm = ({
   const typeSelectOptions = useMemo(
     () => Object.keys(navigationItemType).map((key) => ({
       value: key,
-      label: formatMessage({
-        id: `${pluginId}.popup.item.form.type.${key.toLowerCase()}.label`,
-      }),
+      label: formatMessage(getTrad(`popup.item.form.type.${key.toLowerCase()}.label`)),
     })),
     [],
   );
@@ -180,9 +178,7 @@ const NavigationItemForm = ({
       return (
         <Text fontSize="sm" color="grey">
           <FontAwesomeIcon icon={faEye} />{' '}
-          {formatMessage({
-            id: `${pluginId}.popup.item.form.path.preview`,
-          })}{' '}
+          {formatMessage(getTrad('popup.item.form.path.preview'))}{' '}
           {data.levelPath !== '/' ? `${data.levelPath}` : ''}/{form.path}
         </Text>
       );
@@ -226,10 +222,10 @@ const NavigationItemForm = ({
                 <Input
                   autoFocus
                   error={get(formErrors, `${inputsPrefix}title`)}
-                  label={`${pluginId}.popup.item.form.title.label`}
+                  label={getTradId('popup.item.form.title.label')}
                   name={`${inputsPrefix}title`}
                   onChange={onChange}
-                  placeholder={`${pluginId}.popup.item.form.title.placeholder`}
+                  placeholder={getTradId('popup.item.form.title.placeholder')}
                   type="text"
                   validations={{ required: true }}
                   value={get(form, `${inputsPrefix}title`, '')}
@@ -240,9 +236,7 @@ const NavigationItemForm = ({
                   <Label
                     htmlFor={`${inputsPrefix}menuAttached`}
                     style={{ display: 'block' }}
-                    message={formatMessage({
-                      id: `${pluginId}.popup.item.form.menuAttached.label`,
-                    })}
+                    message={formatMessage(getTrad('popup.item.form.menuAttached.label'))}
                   />
                   <Toggle
                     name={`${inputsPrefix}menuAttached`}
@@ -257,10 +251,10 @@ const NavigationItemForm = ({
               <div className="col-lg-7 col-md-12">
                 <Input
                   error={get(formErrors, `${inputsPrefix}${pathSourceName}`)}
-                  label={`${pluginId}.popup.item.form.${pathSourceName}.label`}
+                  label={getTradId(`popup.item.form.${pathSourceName}.label`)}
                   name={`${inputsPrefix}${pathSourceName}`}
                   onChange={onChange}
-                  placeholder={`${pluginId}.popup.item.form.${pathSourceName}.placeholder`}
+                  placeholder={getTradId(`popup.item.form.${pathSourceName}.placeholder`)}
                   description={generatePreviewPath()}
                   type="text"
                   validations={{ required: true }}
@@ -270,9 +264,7 @@ const NavigationItemForm = ({
               <div className="col-lg-5 col-md-12">
                 <Label
                   htmlFor={`${inputsPrefix}type`}
-                  message={formatMessage({
-                    id: `${pluginId}.popup.item.form.type.label`,
-                  })}
+                  message={formatMessage(getTrad('popup.item.form.type.label'))}
                 />
                 <Enumeration
                   name={`${inputsPrefix}type`}
@@ -286,9 +278,7 @@ const NavigationItemForm = ({
               <div className="col-lg-12">
                 <Label
                   htmlFor={`${inputsPrefix}audience`}
-                  message={formatMessage({
-                    id: `${pluginId}.popup.item.form.audience.label`,
-                  })}
+                  message={formatMessage(getTrad('popup.item.form.audience.label'))}
                 />
                 <Select
                   name={`${inputsPrefix}audience`}
@@ -305,9 +295,7 @@ const NavigationItemForm = ({
                   <div className="col-lg-12">
                     <hr />
                     <Label
-                      message={formatMessage({
-                        id: `${pluginId}.popup.item.form.relatedSection.label`,
-                      })}
+                      message={formatMessage(getTrad('popup.item.form.relatedSection.label'))}
                     />
                   </div>
                 </div>
@@ -315,9 +303,7 @@ const NavigationItemForm = ({
                   <div className="col-lg-6 col-md-12">
                     <Label
                       htmlFor={`${inputsPrefix}relatedType`}
-                      message={formatMessage({
-                        id: `${pluginId}.popup.item.form.relatedType.label`,
-                      })}
+                      message={formatMessage(getTrad('popup.item.form.relatedType.label'))}
                     />
                     <Select
                       name={`${inputsPrefix}relatedType`}
@@ -331,9 +317,7 @@ const NavigationItemForm = ({
                     <div className="col-lg-6 col-md-12">
                       <Label
                         htmlFor={relatedFieldName}
-                        message={formatMessage({
-                          id: `${pluginId}.popup.item.form.related.label`,
-                        })}
+                        message={formatMessage(getTrad('popup.item.form.related.label'))}
                       />
                       <Select
                         name={relatedFieldName}
@@ -350,9 +334,7 @@ const NavigationItemForm = ({
                           fontSize="sm"
                         >
                           <FontAwesomeIcon icon={faInfoCircle} />{' '}
-                          {formatMessage({
-                            id: `${pluginId}.popup.item.form.related.empty`,
-                          }, { contentTypeName: get(relatedTypeSelectValue, 'label') })}
+                          {formatMessage(getTrad('popup.item.form.related.empty'), { contentTypeName: get(relatedTypeSelectValue, 'label') })}
                         </Text>)}
                     </div>
                   )}
@@ -367,18 +349,16 @@ const NavigationItemForm = ({
           <Button
             onClick={handleRemove}
             color="delete"
-            label={formatMessage({
-              id: `${pluginId}.popup.item.form.button.remove`,
-            })}
+            label={formatMessage(getTrad('popup.item.form.button.remove'))}
           />
         </section>
         <section>
           <ButtonModal
             onClick={handleSubmit}
             disabled={submitDisabled}
-            message={`${pluginId}.popup.item.form.button.${
+            message={getTradId(`popup.item.form.button.${
               form.viewId ? 'update' : 'create'
-            }`}
+            }`)}
           />
         </section>
       </ModalFooter>

--- a/admin/src/containers/View/components/NavigationItemForm/utils/form.js
+++ b/admin/src/containers/View/components/NavigationItemForm/utils/form.js
@@ -23,7 +23,10 @@ export const form = {
           is: val => val === navigationItemType.EXTERNAL,
           then: yup.string()
             .required(translatedErrors.required)
-            .url(`${pluginId}.popup.item.form.externalPath.validation.type`),
+            .matches(/(#.*)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/, { 
+              excludeEmptyString: true,
+              message: `${pluginId}.popup.item.form.externalPath.validation.type`,
+            }),
           otherwise: yup.string().notRequired(),
         }),
       menuAttached: yup.boolean(),

--- a/admin/src/containers/View/components/NavigationItemPopup/index.js
+++ b/admin/src/containers/View/components/NavigationItemPopup/index.js
@@ -10,10 +10,10 @@ import PropTypes from 'prop-types';
 import { HeaderModal, HeaderModalTitle } from 'strapi-helper-plugin';
 import { find } from 'lodash';
 import NavigationItemForm from '../NavigationItemForm';
-import pluginId from '../../../../pluginId';
 import { extractRelatedItemLabel, isRelationCorrect, isRelationPublished } from '../../utils/parsers';
 import { MediumPopup } from './MediumPopup';
 import { navigationItemType } from '../../utils/enums';
+import { getTrad, getTradId } from '../../../../translations';
 
 const NavigationItemPopUp = ({
   isOpen,
@@ -43,17 +43,17 @@ const NavigationItemPopUp = ({
 
 
   const appendLabelPublicationStatus = (label = '', item = {}, isCollection = false) => {
-    const appendix = !isRelationPublished({
+    const appendix = isRelationPublished({
       relatedRef: item,
       type: item.isSingle ? navigationItemType.INTERNAL : item.type, 
       isCollection,
-    }) ? `[${formatMessage({ id: `${pluginId}.notification.navigation.item.relation.status.draft` })}] `.toUpperCase() : '';
+    }) ? '' : `[${formatMessage(getTrad('notification.navigation.item.relation.status.draft'))}] `.toUpperCase();
     return `${appendix}${label}`;
   };
 
-  const relatedTypeItem = find(contentTypes, item => item.uid === relatedType, {});
+  const relatedTypeItem = find(contentTypes, item => item.uid === relatedType);
   const prepareFormData = data => {
-    const relatedItem = find(contentTypeItems, item => item.id === related, {});
+    const relatedItem = find(contentTypeItems, item => item.id === related);
     return {
       ...data,
       type: isRelationCorrect(data) ? data.type : undefined,
@@ -79,7 +79,7 @@ const NavigationItemPopUp = ({
       <HeaderModal>
         <section>
           <HeaderModalTitle>
-            <FormattedMessage id={`${pluginId}.popup.item.header`} />
+            <FormattedMessage id={getTradId('popup.item.header')} />
           </HeaderModalTitle>
         </section>
       </HeaderModal>

--- a/admin/src/containers/View/components/NavigationItemPopup/index.js
+++ b/admin/src/containers/View/components/NavigationItemPopup/index.js
@@ -4,15 +4,16 @@
  *
  */
 
-import React, { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
+import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { HeaderModal, HeaderModalTitle } from 'strapi-helper-plugin';
 import { find } from 'lodash';
 import NavigationItemForm from '../NavigationItemForm';
 import pluginId from '../../../../pluginId';
-import { extractRelatedItemLabel } from '../../utils/parsers';
+import { extractRelatedItemLabel, isRelationCorrect, isRelationPublished } from '../../utils/parsers';
 import { MediumPopup } from './MediumPopup';
+import { navigationItemType } from '../../utils/enums';
 
 const NavigationItemPopUp = ({
   isOpen,
@@ -25,6 +26,8 @@ const NavigationItemPopUp = ({
   getContentTypeItems,
   usedContentTypesData,
 }) => {
+  const { formatMessage } = useIntl();
+
   const handleOnSubmit = (payload) => {
     onSubmit(payload);
   };
@@ -38,21 +41,38 @@ const NavigationItemPopUp = ({
     contentTypesNameFields = {},
   } = config;
 
+
+  const appendLabelPublicationStatus = (label = '', item = {}, isCollection = false) => {
+    const appendix = !isRelationPublished({
+      relatedRef: item,
+      type: item.isSingle ? navigationItemType.INTERNAL : item.type, 
+      isCollection,
+    }) ? `[${formatMessage({ id: `${pluginId}.notification.navigation.item.relation.status.draft` })}] `.toUpperCase() : '';
+    return `${appendix}${label}`;
+  };
+
   const relatedTypeItem = find(contentTypes, item => item.uid === relatedType, {});
-  const prepareFormData = data => ({
-    ...data,
-    related: related ? {
-      value: related,
-      label: extractRelatedItemLabel({
-        ...find(contentTypeItems, item => item.id === related, {}),
-        __collectionName: relatedType,
-      }, contentTypesNameFields, config),
-    } : undefined,
-    relatedType: relatedType ? {
-      value: relatedType,
-      label: relatedTypeItem.label || relatedTypeItem.name,
-    } : undefined,
-  });
+  const prepareFormData = data => {
+    const relatedItem = find(contentTypeItems, item => item.id === related, {});
+    return {
+      ...data,
+      type: isRelationCorrect(data) ? data.type : undefined,
+      related: related && isRelationCorrect(data) ? {
+        value: related,
+        label: appendLabelPublicationStatus(
+            extractRelatedItemLabel({
+            ...relatedItem,
+            __collectionName: relatedType,
+          }, contentTypesNameFields, config),
+          relatedItem,
+        ),
+      } : undefined,
+      relatedType: relatedType && isRelationCorrect(data) ? {
+        value: relatedType,
+        label: appendLabelPublicationStatus(relatedTypeItem.label || relatedTypeItem.name, relatedTypeItem, true),
+      } : undefined,
+    };
+  };
 
   return (
     <MediumPopup isOpen={isOpen} onToggle={onClose}>
@@ -75,6 +95,7 @@ const NavigationItemPopUp = ({
         getContentTypeEntities={getContentTypeItems}
         usedContentTypesData={usedContentTypesData}
         onSubmit={handleOnSubmit}
+        appendLabelPublicationStatus={appendLabelPublicationStatus}
       />
     </MediumPopup>
   );

--- a/admin/src/containers/View/index.js
+++ b/admin/src/containers/View/index.js
@@ -22,7 +22,9 @@ import NavigationItemPopUp from "./components/NavigationItemPopup";
 import List from "../../components/List";
 import {
   transformItemToViewPayload,
-  transformToRESTPayload, usedContentTypes,
+  transformToRESTPayload, 
+  usedContentTypes,
+  validateNavigationStructure,
 } from './utils/parsers';
 import FadedWrapper from "./FadedWrapper";
 
@@ -52,6 +54,7 @@ const View = () => {
     label: item.name,
   }));
 
+  const structureHasErrors = !validateNavigationStructure((changedActiveNavigation || {}).items);
   const navigationSelectValue = get(activeNavigation, "id", null);
   const actions = [
     {
@@ -63,10 +66,11 @@ const View = () => {
     {
       label: "Save",
       onClick: () =>
-        isLoadingForSubmit ? null : handleSubmitNavigation(formatMessage, transformToRESTPayload(changedActiveNavigation, config)),
+        isLoadingForSubmit || structureHasErrors ? null : handleSubmitNavigation(formatMessage, transformToRESTPayload(changedActiveNavigation, config)),
       color: "success",
       type: "submit",
       isLoading: isLoadingForSubmit,
+      disabled: structureHasErrors,
     },
   ];
 
@@ -210,6 +214,7 @@ const View = () => {
                     root
                     error={error}
                     allowedLevels={config.allowedLevels}
+                    contentTypes={config.contentTypes}
                     isParentAttachedToMenu={true}
                     contentTypesNameFields={config.contentTypesNameFields}
                   />

--- a/admin/src/containers/View/index.js
+++ b/admin/src/containers/View/index.js
@@ -17,7 +17,6 @@ import Wrapper from "../View/Wrapper";
 import EmptyView from "../../components/EmptyView";
 import HeaderForm from "./HeaderForm";
 import HeaderFormCell from "./HeaderFormCell";
-import pluginId from "../../pluginId";
 import NavigationItemPopUp from "./components/NavigationItemPopup";
 import List from "../../components/List";
 import {
@@ -27,6 +26,7 @@ import {
   validateNavigationStructure,
 } from './utils/parsers';
 import FadedWrapper from "./FadedWrapper";
+import { getTrad, getTradId } from '../../translations';
 
 const View = () => {
   const {
@@ -167,11 +167,9 @@ const View = () => {
             <HeaderFormCell>
               <Header
                 title={{
-                  label: formatMessage({ id: `${pluginId}.header.title` }),
+                  label: formatMessage(getTrad('header.title')),
                 }}
-                content={formatMessage({
-                  id: `${pluginId}.header.description`,
-                })}
+                content={formatMessage(getTrad('header.description'))}
               />
             </HeaderFormCell>
             { options && (options.length > 1) && (<HeaderFormCell>
@@ -195,11 +193,11 @@ const View = () => {
                 {isEmpty(changedActiveNavigation.items || []) && (
                   <EmptyView>
                     <FontAwesomeIcon icon={faHamburger} size="5x" />
-                    <FormattedMessage id={`${pluginId}.empty`} />
+                    <FormattedMessage id={getTradId('empty')} />
                     <Button
                       color="primary"
                       icon={<FontAwesomeIcon icon={faPlus} />}
-                      label={formatMessage({ id: `${pluginId}.empty.cta` })}
+                      label={formatMessage(getTrad('empty.cta'))}
                       onClick={addNewNavigationItem}
                     />
                   </EmptyView>

--- a/admin/src/containers/View/utils/parsers.js
+++ b/admin/src/containers/View/utils/parsers.js
@@ -1,5 +1,5 @@
 import { isUuid, uuid } from 'uuidv4';
-import { find, first, get, isArray, isEmpty, isNil, isNumber, isObject, isString, omit, orderBy } from 'lodash';
+import { find, first, get, isArray, isEmpty, isNil, isNumber, isObject, isString, kebabCase, omit, orderBy } from 'lodash';
 import { navigationItemType } from './enums';
 
 export const transformItemToRESTPayload = (
@@ -120,7 +120,7 @@ const linkRelations = (item, config) => {
   const shouldBuildRelated = !relatedRef || (relatedRef && (relatedRef.id !== relatedId));
   if (shouldBuildRelated && !shouldFindRelated) {
     const relatedContentType = find(contentTypes,
-      ct => ct.contentTypeName.toLowerCase() === relatedItem.__contentType.toLowerCase(), {});
+      ct => kebabCase(ct.contentTypeName) === kebabCase(relatedItem.__contentType), {});
     const { uid, labelSingular, isSingle } = relatedContentType;
     relation = {
       related: relatedItem.id,

--- a/admin/src/containers/View/utils/parsers.js
+++ b/admin/src/containers/View/utils/parsers.js
@@ -277,18 +277,18 @@ export const isRelationPublished = ({ relatedRef, relatedType = {}, type, isColl
   }
   if ((type === navigationItemType.INTERNAL)) {
     const isHandledByPublshFlow =  relatedRef ? 'published_at' in relatedRef : false;
-    return relatedRef ?
-      (isHandledByPublshFlow && get(relatedRef, 'published_at')) :
-      true;
+    if (isHandledByPublshFlow) {
+      return get(relatedRef, 'published_at', true);
+    }
   }
   return true;
 };
 
 export const validateNavigationStructure = (items = []) => 
   items.map(item => 
-    (isRelationCorrect({ 
+    (item.removed || isRelationCorrect({ 
       related: item.related, 
       type: item.type,
-    }) || item.removed) && 
+    })) && 
     validateNavigationStructure(item.items)
   ).filter(item => !item).length === 0;

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -30,5 +30,8 @@
   "popup.item.form.button.restore": "Restore item",
   "popup.item.form.button.remove": "Remove",
   "notification.navigation.submit": "Navigation changes has been saved",
-  "notification.navigation.error": "Duplicate path: { path } in parent: { parentTitle } for { errorTitles } items"
+  "notification.navigation.error": "Duplicate path: { path } in parent: { parentTitle } for { errorTitles } items",
+  "notification.navigation.item.relation": "Entity relation does not exist!",
+  "notification.navigation.item.relation.status.draft": "draft",
+  "notification.navigation.item.relation.status.published": "published"
 }

--- a/admin/src/translations/index.js
+++ b/admin/src/translations/index.js
@@ -1,7 +1,11 @@
+import pluginId from "../pluginId";
 import en from "./en.json";
 
 const trads = {
   en,
 };
+
+export const getTradId = (msg) => `${pluginId}.${msg}`;
+export const getTrad = (msg) => ({id: getTradId(msg)});
 
 export default trads;

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "reactstrap": "8.4.1",
     "redux-saga": "^0.16.0",
     "request": "^2.83.0",
-    "strapi-helper-plugin": "3.5.0",
-    "strapi-utils": "3.5.0",
+    "strapi-helper-plugin": "3.5.2",
+    "strapi-utils": "3.5.2",
     "uuidv4": "^6.2.6",
     "slugify": "^1.4.5",
     "pluralize": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "Navigation",

--- a/services/__tests__/navigation.test.js
+++ b/services/__tests__/navigation.test.js
@@ -9,7 +9,7 @@ describe('Navigation service', () => {
       expect(strapi.contentTypes).toBeDefined();
       expect(Object.keys(strapi.contentTypes).length).toBe(2);
     });
-  it('Config Content Types', () => {
+  it('Config Content Types', async () => {
       const { configContentTypes } = require("../navigation");
       const result = [{
           uid: "application::pages.pages",
@@ -32,7 +32,7 @@ describe('Navigation service', () => {
           name: "blog-post",
           visible: true,
       }];
-      const types = configContentTypes();
+      const types = await configContentTypes();
       expect(types[0]).toMatchObject(result[0]);
       expect(types[1]).toMatchObject(result[1]);
     });

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -21,8 +21,7 @@ const {
 const { KIND_TYPES } = require("./utils/constant");
 const utilsFunctions = require('./utils/functions');
 const { renderType } = require('../models/navigation');
-const { type: itemType } = require('../models/navigationItem');
-const navigationItem = require('../models/navigationItem');
+const { type: itemType, additionalFields: configAdditionalFields } = require('../models/navigationItem');
 
 /**
  * navigation.js service
@@ -59,7 +58,7 @@ module.exports = {
       additionalFields,
     };
 
-    if (additionalFields.includes(navigationItem.additionalFields.AUDIENCE)) {
+    if (additionalFields.includes(configAdditionalFields.AUDIENCE)) {
       const audienceItems = await strapi
         .query(audienceModel.modelName, pluginName)
         .find({});
@@ -353,7 +352,7 @@ module.exports = {
         parent,
       });
 
-      if (item.type === navigationItem.type.INTERNAL) {
+      if (item.type === itemType.INTERNAL) {
         pages = {
           ...pages,
           [itemPage.id]: {
@@ -373,7 +372,7 @@ module.exports = {
         };
       } else {
         const navLevel = navItems
-          .filter(navItem => navItem.type === navigationItem.type.INTERNAL.toLowerCase());
+          .filter(navItem => navItem.type === itemType.INTERNAL.toLowerCase());
         if (!isEmpty(navLevel))
           nav = {
             ...nav,
@@ -389,7 +388,7 @@ module.exports = {
           contentTypes,
         });
         const { pages: nestedPages } = service.renderRFR({
-          items: itemChilds.filter(child => child.type === navigationItem.type.INTERNAL), 
+          items: itemChilds.filter(child => child.type === itemType.INTERNAL), 
           parent: itemPage.id, 
           parentNavItem: itemNav, 
           contentTypes,
@@ -419,7 +418,7 @@ module.exports = {
       id: uiRouterKey,
       title,
       templateName: __templateName,
-      related: type === navigationItem.type.INTERNAL ? {
+      related: type === itemType.INTERNAL ? {
         contentType: kebabCase(contentType),
         id,
       } : undefined,
@@ -436,8 +435,8 @@ module.exports = {
     return {
       label: title,
       type: type.toLowerCase(),
-      page: type === navigationItem.type.INTERNAL ? uiRouterKey : undefined,
-      url: type === navigationItem.type.EXTERNAL ? path : undefined,
+      page: type === itemType.INTERNAL ? uiRouterKey : undefined,
+      url: type === itemType.EXTERNAL ? path : undefined,
       audience,
     };
   },

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -13,6 +13,7 @@ const {
   find,
   first,
   get,
+  kebabCase,
   last,
   upperFirst,
   isString,
@@ -28,6 +29,8 @@ const navigationItem = require('../models/navigationItem');
  *
  * @description: A set of functions similar to controller's actions to avoid code duplication.
  */
+
+const excludedContentTypes = ['strapi::'];
 
 const contentTypesNameFieldsDefaults = [
   "title",
@@ -47,7 +50,7 @@ module.exports = {
     const additionalFields = get(strapi.config, 'custom.plugins.navigation.additionalFields', []);
     let extendedResult = {};
     const result = {
-      contentTypes: service.configContentTypes(),
+      contentTypes: await service.configContentTypes(),
       contentTypesNameFields: {
         default: contentTypesNameFieldsDefaults,
         ...(isObject(contentTypesNameFields) ? contentTypesNameFields : {}),
@@ -73,15 +76,39 @@ module.exports = {
     };
   },
 
-  configContentTypes: () =>
-    Object.keys(strapi.contentTypes)
-      .filter(
-        (key) => {
-          const item = strapi.contentTypes[key];
-          return (item.associations || []).some(_ => _.model === 'navigationitem');
-        },
-      )
-      .map((key) => {
+  configContentTypes: async () => {
+    const eligibleContentTypes =
+      await Promise.all(
+        Object.keys(strapi.contentTypes)
+        .map(
+          async (key) => {
+            if (find(excludedContentTypes, name => key.includes(name))) { // exclude internal content types
+              return;
+            }
+
+            const item = strapi.contentTypes[key];
+            const { associations = [], kind, options, uid } = item;
+            const { draftAndPublish } = options;
+            const hasDefinedNavigationRelation = associations.some(_ => _.model === 'navigationitem');
+            const isSingleTypeWithPublishFlow = (kind === KIND_TYPES.SINGLE) && draftAndPublish;
+            const itemsCountOrBypass = isSingleTypeWithPublishFlow ? await strapi.query(uid).count({
+              _publicationState: 'live'
+            }) : await Promise.resolve(true);
+            return hasDefinedNavigationRelation ? {
+              key,
+              available: itemsCountOrBypass !== 0,
+            } : undefined;
+          }
+        )
+      );
+    return eligibleContentTypes
+      .map((keyValue) => {
+
+        if (!keyValue) {
+          return;
+        }
+
+        const { key, available } = keyValue;
         const item = strapi.contentTypes[key];
         const relatedField = (item.associations || []).find(_ => _.model === 'navigationitem');
         const { uid, options, info, collectionName, apiName, plugin, kind } = item;
@@ -92,7 +119,7 @@ module.exports = {
         const relationName = utilsFunctions.singularize(apiName);
         const relationNameParts = last(uid.split('.')).split('-');
         const contentTypeName = relationNameParts.length > 1 ? relationNameParts.reduce((prev, curr) => `${prev}${upperFirst(curr)}`, '') : upperFirst(apiName);
-        const labelSingular = upperFirst(relationNameParts.length > 1 ? relationNameParts.join(' ') : relationName);
+        const labelSingular = name || (upperFirst(relationNameParts.length > 1 ? relationNameParts.join(' ') : relationName));
         return {
           uid,
           name: relationName,
@@ -100,15 +127,17 @@ module.exports = {
           description,
           collectionName,
           contentTypeName,
-          label: isSingle ? labelSingular : pluralize(labelSingular || name),
+          label: isSingle ? labelSingular : pluralize(name || labelSingular),
           relatedField: relatedField ? relatedField.alias : undefined,
           labelSingular: utilsFunctions.singularize(labelSingular),
           endpoint,
           plugin,
+          available,
           visible: (isManaged || isNil(isManaged)) && !hidden,
         };
       })
-      .filter((item) => item.visible),
+      .filter((item) => item && item.visible);
+  },
 
   // Get all available navigations
   get: async () => {
@@ -226,7 +255,8 @@ module.exports = {
       if (!items) {
         return [];
       }
-      const getTemplateName = await utilsFunctions.templateNameFactory(items, strapi, service.configContentTypes())
+      const contentTypes = await service.configContentTypes();
+      const getTemplateName = await utilsFunctions.templateNameFactory(items, strapi, contentTypes)
 
       switch (type) {
         case renderType.TREE:
@@ -235,7 +265,7 @@ module.exports = {
             const isExternal = item.type === itemType.EXTERNAL;
             const parentPath = isExternal ? undefined : `${path === '/' ? '' : path}/${item.path === '/' ? '' : item.path}`;
             const slug = isString(parentPath) ? slugify((first(parentPath) === '/' ? parentPath.substring(1) : parentPath).replace(/\//g, '-')) : undefined;
-            const lastRelated = last(item.related);
+            const lastRelated = item.related ? last(item.related) : undefined;
             return {
               title: item.title,
               menuAttached: item.menuAttached,
@@ -249,44 +279,47 @@ module.exports = {
                 __templateName: getTemplateName(lastRelated.__contentType, lastRelated.id),
               },
               audience: !isEmpty(item.audience) ? item.audience.map(aItem => aItem.key) : undefined,
-              items: isExternal ? undefined : service.renderTree(
+              items: isExternal ? undefined : service.renderTree({
                 items,
-                item.id,
+                id: item.id,
                 field,
-                parentPath,
+                path: parentPath,
                 itemParser,
-              ),
+              }),
             };
           };
-          const treeStructure = service.renderTree(
+          const treeStructure = service.renderTree({
             items,
-            null,
-            'parent',
-            undefined,
+            field: 'parent',
             itemParser,
-          );
+          });
           if (type === renderType.RFR) {
-            return service.renderRFR(treeStructure);
+            return service.renderRFR({
+              items: treeStructure, 
+              contentTypes,
+            });
           }
           return treeStructure;
         default:
-          return items.map((item) => ({
-            ...sanitizeEntity(item, { model: itemModel }),
-            related: item.related,
-            items: null,
-          }));
+          return items
+            .filter(utilsFunctions.filterOutUnpublished)
+            .map((item) => ({
+              ...sanitizeEntity(item, { model: itemModel }),
+              related: item.related,
+              items: null,
+            }));
       }
     }
     throw strapi.errors.notFound();
   },
 
-  renderTree: (
+  renderTree: ({ 
     items = [],
     id = null,
     field = 'parent',
     path = '',
     itemParser = (i) => i,
-  ) => {
+  }) => {
     return items
       .filter(
         (item) => {
@@ -300,12 +333,13 @@ module.exports = {
           return (data && data === id) || (isObject(item[field]) && (item[field].id === id));
         },
       )
+      .filter(utilsFunctions.filterOutUnpublished)
       .map(item => itemParser({
         ...item
       }, path, field));
   },
 
-  renderRFR: (items, parent = null, parentNavItem = null) => {
+  renderRFR: ({ items, parent = null, parentNavItem = null, contentTypes = [] }) => {
     const { service } = utilsFunctions.extractMeta(strapi.plugins);
     let pages = {};
     let nav = {};
@@ -314,7 +348,10 @@ module.exports = {
     items.forEach(item => {
       const { items: itemChilds, ...itemProps } = item;
       const itemNav = service.renderRFRNav(itemProps);
-      const itemPage = service.renderRFRPage(itemProps, parent);
+      const itemPage = service.renderRFRPage({
+        item: itemProps, 
+        parent,
+      });
 
       if (item.type === navigationItem.type.INTERNAL) {
         pages = {
@@ -345,9 +382,18 @@ module.exports = {
       }
 
       if (!isEmpty(itemChilds)) {
-        const { nav: nestedNavs } = service.renderRFR(itemChilds, itemPage.id, itemNav);
-        const { pages: nestedPages } = service.renderRFR(
-          itemChilds.filter(child => child.type === navigationItem.type.INTERNAL), itemPage.id, itemNav);
+        const { nav: nestedNavs } = service.renderRFR({
+          items: itemChilds, 
+          parent: itemPage.id, 
+          parentNavItem: itemNav,
+          contentTypes,
+        });
+        const { pages: nestedPages } = service.renderRFR({
+          items: itemChilds.filter(child => child.type === navigationItem.type.INTERNAL), 
+          parent: itemPage.id, 
+          parentNavItem: itemNav, 
+          contentTypes,
+        });
         pages = {
           ...pages,
           ...nestedPages,
@@ -365,20 +411,16 @@ module.exports = {
     };
   },
 
-  renderRFRPage: (item, parent) => {
-    const { service } = utilsFunctions.extractMeta(strapi.plugins);
+  renderRFRPage: ({ item, parent }) => {
     const { uiRouterKey, title, path, slug, related, type, audience, menuAttached } = item;
     const { __contentType, id, __templateName } = related || {};
-    const contentTypes = service.configContentTypes();
-    const contentType = (__contentType || '').toLowerCase() || undefined;
-    const { collectionName } = find(contentTypes, ctItem => ctItem.name === contentType) || {};
+    const contentType = __contentType || '';
     return {
       id: uiRouterKey,
       title,
       templateName: __templateName,
       related: type === navigationItem.type.INTERNAL ? {
-        contentType,
-        collectionName,
+        contentType: kebabCase(contentType),
         id,
       } : undefined,
       path,

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -139,10 +139,14 @@ module.exports = {
     filterOutUnpublished(item) {
       const relatedItem = item.related && last(item.related);
       const isHandledByPublshFlow =  relatedItem ? 'published_at' in relatedItem : false;
-      const isRelatedDefinedAndPublished = relatedItem ?
-        isHandledByPublshFlow && get(relatedItem, 'published_at') :
-        false;
-      return item.type === itemType.INTERNAL ? isRelatedDefinedAndPublished  : true
+
+      if (isHandledByPublshFlow) {
+        const isRelatedDefinedAndPublished = relatedItem ?
+          isHandledByPublshFlow && get(relatedItem, 'published_at') :
+          false;
+        return item.type === itemType.INTERNAL ? isRelatedDefinedAndPublished  : true;
+      }
+      return (item.type === itemType.EXTERNAL) || relatedItem;
     },
 
     prepareAuditLog(actions) {

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -9,6 +9,7 @@ const {
     last,
   } = require('lodash');
 
+const { type: itemType } = require('../../models/navigationItem');
 const { NavigationError } = require('../../utils/NavigationError');
 const { TEMPLATE_DEFAULT } = require('./constant');
 
@@ -133,6 +134,15 @@ module.exports = {
       if (auditLogInstance && auditLogInstance.emit) {
         auditLogInstance.emit(event, data);
       }
+    },
+
+    filterOutUnpublished(item) {
+      const relatedItem = item.related && last(item.related);
+      const isHandledByPublshFlow =  relatedItem ? 'published_at' in relatedItem : false;
+      const isRelatedDefinedAndPublished = relatedItem ?
+        isHandledByPublshFlow && get(relatedItem, 'published_at') :
+        false;
+      return item.type === itemType.INTERNAL ? isRelatedDefinedAndPublished  : true
     },
 
     prepareAuditLog(actions) {

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -41,7 +41,7 @@ module.exports = {
           if (parentItem && parentItem.items) {
             for (let item of checkData) {
               for (let _ of parentItem.items) {
-                if (_.path === item.path && _.id !== item.id) {
+                if (_.path === item.path && (_.id !== item.id) && (item.type === itemType.INTERNAL)) {
                   return reject(
                     new NavigationError(
                       `Duplicate path:${item.path} in parent: ${parentItem.title || 'root'} for ${item.title} and ${_.title} items`,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/42
https://github.com/VirtusLab/strapi-plugin-navigation/issues/44

## Summary

What does this PR do/solve? 

- adds coverage for built-in Strapi draft & publish flow
- prevents 500 error when content type entity has been accidentally removed
- filter outs removed and draft entities from render output

## Test Plan

- play with single & collection types
- play with the publish status
