### PR TITLE
feat: support for templates on single types

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,14 @@ Return a rendered navigation structure depends on passed type (`tree`, `rfr` or 
 }
 ```
 
+### Template name
+
+Depending on a content type `templateName` will be resolved differently
+
+For collection types it will be read from content type's attribute name `template` holding a component which definition has option named `templateName`.
+
+For single types a global name of this content type will be used as a template name or it can be set manually with an option named `templateName`.
+
 ## Audit log
 If you would like to use the [Strapi Molecules Audit Log](https://github.com/VirtusLab/strapi-molecules/tree/master/packages/strapi-plugin-audit-log) plugin you've to first install and then add in you `config/middleware.js` following section enable it:
 ```js

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -86,7 +86,7 @@ module.exports = {
         const relatedField = (item.associations || []).find(_ => _.model === 'navigationitem');
         const { uid, options, info, collectionName, apiName, plugin, kind } = item;
         const { name, description } = info;
-        const { isManaged, hidden } = options;
+        const { isManaged, hidden, templateName } = options;
         const isSingle = kind === KIND_TYPES.SINGLE;
         const endpoint = isSingle ? apiName : pluralize(apiName);
         const relationName = utilsFunctions.singularize(apiName);
@@ -106,6 +106,7 @@ module.exports = {
           endpoint,
           plugin,
           visible: (isManaged || isNil(isManaged)) && !hidden,
+          templateName,
         };
       })
       .filter((item) => item.visible),

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -107,10 +107,10 @@ module.exports = {
               }),
       );
       const relatedResponseMap = responses.reduce((acc, curr) => ({ ...acc, ...curr }), {});
-      const singleTypes = new Set( 
+      const singleTypes = new Map( 
         contentTypes
           .filter(x => x.isSingle)
-          .map(({ contentTypeName }) => contentTypeName)
+          .map(({ contentTypeName, templateName }) => [contentTypeName, templateName || contentTypeName])
       );
 
       return (contentType, id) => {
@@ -121,8 +121,8 @@ module.exports = {
           return get(templateComponent, 'options.templateName', TEMPLATE_DEFAULT);
         }
 
-        if (singleTypes.has(contentType)) {
-          return contentType;
+        if (singleTypes.get(contentType)) {
+          return singleTypes.get(contentType);
         }
 
         return TEMPLATE_DEFAULT;

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -107,11 +107,25 @@ module.exports = {
               }),
       );
       const relatedResponseMap = responses.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+      const singleTypes = new Set( 
+        contentTypes
+          .filter(x => x.isSingle)
+          .map(({ contentTypeName }) => contentTypeName)
+      );
 
       return (contentType, id) => {
         const template = get(relatedResponseMap[contentType].find(data => data.id === id), 'template');
-        const templateComponent = this.getTemplateComponentFromTemplate(template);
-        return get(templateComponent, 'options.templateName', TEMPLATE_DEFAULT);
+
+        if (template) {
+          const templateComponent = this.getTemplateComponentFromTemplate(template);
+          return get(templateComponent, 'options.templateName', TEMPLATE_DEFAULT);
+        }
+
+        if (singleTypes.has(contentType)) {
+          return contentType;
+        }
+
+        return TEMPLATE_DEFAULT;
       };
     },
 


### PR DESCRIPTION
## Summary

Template names support for a single type

## Test Plan

- Create a single type if not present
- Provide data for single type
- Add navigation item pointing to a single type
- Render navigation
- Update override `templateName` in section `options` of `.settings.json` file 
- Render navigation