### PR TITLE
fix: content types search limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Complete installation requirements are exact same as for Strapi itself and can b
 
 **Supported Strapi versions**:
 
-- Strapi v3.5.2 (recently tested)
+- Strapi v3.5.3 (recently tested)
 - Strapi v3.x
 
 (This plugin may work with the older Strapi versions, but these are not tested nor officially supported at this time.)

--- a/admin/src/components/Select/index.js
+++ b/admin/src/components/Select/index.js
@@ -10,7 +10,7 @@ import IndicatorSeparator from './IndicatorSeparator';
 import MultiValueContainer from './MultiValueContainer';
 import { useIntl } from 'react-intl';
 
-const Select = ({ error, isDisabled, isMulti, isLoading, name, onChange, value, defaultValue, options }) => {
+const Select = ({ error, isDisabled, isMulti, isLoading, name, onChange, onInputChange, value, inputValue, defaultValue, options }) => {
   const { formatMessage } = useIntl();
   const translatedError = error && error.id ? formatMessage(error) : null;
 
@@ -29,6 +29,7 @@ const Select = ({ error, isDisabled, isMulti, isLoading, name, onChange, value, 
         onChange={data => {
           onChange({ target: { name, value: data } });
         }}
+        onInputChange={onInputChange}
         isClearable
         isDisabled={isDisabled}
         isLoading={isLoading}
@@ -36,6 +37,7 @@ const Select = ({ error, isDisabled, isMulti, isLoading, name, onChange, value, 
         options={isLoading ? [] : options}
         styles={styles}
         defaultValue={defaultValue}
+        inputValue={inputValue}
         value={isLoading ? undefined : value}
       />
       {error && value.length === 0 ? (

--- a/admin/src/containers/DataManagerProvider/index.js
+++ b/admin/src/containers/DataManagerProvider/index.js
@@ -161,12 +161,19 @@ const DataManagerProvider = ({ children }) => {
     }
   }, [autoReload, currentEnvironment]);
 
-  const getContentTypeItems = async (type, plugin = "") => {
+  const getContentTypeItems = async ({type, query}, plugin = "") => {
     dispatch({
       type: GET_CONTENT_TYPE_ITEMS,
     });
     const url = plugin ? `/${plugin}/${type}` : `/${type}`;
-    const contentTypeItems = await request(`${url}?_publicationState=preview`, {
+
+    const queryParams = new URLSearchParams();
+    queryParams.append('_publicationState', 'preview');
+    if (query) {
+      queryParams.append('_q', query);
+    }
+
+    const contentTypeItems = await request(`${url}?${queryParams.toString()}`, {
       method: "GET",
       signal,
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "Navigation",
@@ -27,8 +27,8 @@
     "reactstrap": "8.4.1",
     "redux-saga": "^0.16.0",
     "request": "^2.83.0",
-    "strapi-helper-plugin": "3.5.2",
-    "strapi-utils": "3.5.2",
+    "strapi-helper-plugin": "3.5.3",
+    "strapi-utils": "3.5.3",
     "uuidv4": "^6.2.6",
     "slugify": "^1.4.5",
     "pluralize": "^8.0.0"


### PR DESCRIPTION
## Ticket

N/A

## Summary

What does this PR do/solve? 

- solves the issue while searching for content types (more than 100 instances)
- provides typeahead functionality for content types select

## Test Plan

- run and play with the content type search
