### PR TITLE
fix: drop query limits in the service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "Navigation",

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -61,7 +61,9 @@ module.exports = {
     if (additionalFields.includes(configAdditionalFields.AUDIENCE)) {
       const audienceItems = await strapi
         .query(audienceModel.modelName, pluginName)
-        .find({});
+        .find({
+          _limit: -1,
+        });
       extendedResult = {
         ...extendedResult,
         availableAudience: audienceItems.map((_) =>
@@ -156,7 +158,9 @@ module.exports = {
     const { pluginName, masterModel } = utilsFunctions.extractMeta(strapi.plugins);
     const entities = await strapi
       .query(masterModel.modelName, pluginName)
-      .find({}, []);
+      .find({
+        _limit: -1,
+      }, []);
     return entities.map((_) => sanitizeEntity(_, { model: masterModel }));
   },
 
@@ -171,6 +175,7 @@ module.exports = {
       .query(itemModel.modelName, pluginName)
       .find({
         master: id,
+        _limit: -1,
         _sort: 'order:asc',
       }, ['related', 'audience']);
 
@@ -259,6 +264,7 @@ module.exports = {
         {
           master: entity.id,
           ...itemCriteria,
+          _limit: -1,
           _sort: 'order:asc',
         },
         ["related", "audience"],


### PR DESCRIPTION
## Ticket

N/A

## Summary

What does this PR do/solve? 

- drops default Strapi query limits to support large navigations

## Test Plan

- might be difficult to get more than 100 items, just play and check if nothing crash
