### PR TITLE
fix: audiences in transform for rest payload

### DIFF
--- a/admin/src/containers/View/utils/parsers.js
+++ b/admin/src/containers/View/utils/parsers.js
@@ -47,7 +47,7 @@ export const transformItemToRESTPayload = (
     uiRouterKey,
     menuAttached,
     audience: audience.map((audienceItem) =>
-      isObject(audienceItem) ? audienceItem.id : audienceItem,
+      isObject(audienceItem) ? audienceItem.value : audienceItem,
     ),
     path: isExternal ? undefined : path,
     externalPath: isExternal ? externalPath : undefined,


### PR DESCRIPTION
## Ticket

N/A

## Summary

What does this PR do/solve? 

Reading audience item id in serialisation function.
In this specific place audienceItem is not an instance of strapi content type but value object coming from `react-select` component.

## Test Plan

- add an audience
- try to add it to a navigation item
- save
- confirm that audience is saved
