### PR TITLE
fix: compatibility with strapi 3.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Complete installation requirements are exact same as for Strapi itself and can b
 
 **Supported Strapi versions**:
 
-- Strapi v3.5.3 (recently tested)
+- Strapi v3.6.0 (recently tested)
 - Strapi v3.x
 
 (This plugin may work with the older Strapi versions, but these are not tested nor officially supported at this time.)

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -38,5 +38,5 @@ module.exports = async () => {
   }
 
   const { actionProvider } = strapi.admin.services.permission;
-  actionProvider.register(actions);
+  await actionProvider.registerMany(actions);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "Navigation",
@@ -27,8 +27,8 @@
     "reactstrap": "8.4.1",
     "redux-saga": "^0.16.0",
     "request": "^2.83.0",
-    "strapi-helper-plugin": "3.5.3",
-    "strapi-utils": "3.5.3",
+    "strapi-helper-plugin": "3.6.0",
+    "strapi-utils": "3.6.0",
     "uuidv4": "^6.2.6",
     "slugify": "^1.4.5",
     "pluralize": "^8.0.0"


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/56

## Summary

What does this PR do/solve? 

Changes bootstrap method to be compatible with `Strapi 3.6.x`

## Test Plan

N/A
