### PR TITLE
fix: audience parsing fails

### DIFF
--- a/admin/src/containers/View/utils/parsers.js
+++ b/admin/src/containers/View/utils/parsers.js
@@ -46,7 +46,7 @@ export const transformItemToRESTPayload = (
     order,
     uiRouterKey,
     menuAttached,
-    audience: audience.map((audienceItem) => audienceItem.value || audienceItem.id,
+    audience: audience.map((audienceItem) => isObject(audienceItem) ? audienceItem.value || audienceItem.id : audienceItem,
     ),
     path: isExternal ? undefined : path,
     externalPath: isExternal ? externalPath : undefined,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/99

## Summary

What does this PR do/solve? 

- fixes problem with nulling of audience when navigation items are edited

## Test Plan

- add navigation item with audience
- edit any field in created navigation item
- audience should not disappear anymore  
