### PR TITLE
fix: default config

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -42,31 +42,11 @@ module.exports = async ({ strapi }) => {
   }
   
   // Initialize configuration
-  const pluginStore = strapi.store({
-    environment: '',
-    type: 'plugin',
-    name: 'navigation',
-  });
+  const config = await strapi.plugin('navigation').service('navigation').setDefaultConfig()
 
-  const config = await pluginStore.get({ key: 'config' });
-  const pluginDefaultConfig = await strapi.plugin('navigation').config
-  const defaultConfigValue = {
-    additionalFields: pluginDefaultConfig('additionalFields'),
-    contentTypes: pluginDefaultConfig('contentTypes'),
-    contentTypesNameFields: pluginDefaultConfig('contentTypesNameFields'),
-    contentTypesPopulate: pluginDefaultConfig('contentTypesPopulate'),
-    allowedLevels: pluginDefaultConfig('allowedLevels'),
-    gql: pluginDefaultConfig('gql'),
-  }
-  
-  if (!config) {
-    pluginStore.set({
-      key: 'config', value: defaultConfigValue
-    });
-  }
-
+  // Initialize graphql configuration
   if (strapi.plugin('graphql')) {
     const graphqlConfiguration = require('./graphql')
-    await graphqlConfiguration({ strapi, config: config || defaultConfigValue });
+    await graphqlConfiguration({ strapi, config });
   }
 };

--- a/server/graphql/types/content-types-name-fields.js
+++ b/server/graphql/types/content-types-name-fields.js
@@ -1,8 +1,8 @@
-module.exports = ({ nexus }) => nexus.objectType({
+module.exports = ({ nexus, strapi }) => nexus.objectType({
   name: "ContentTypesNameFields",
   async definition(t) {
 		t.nonNull.list.nonNull.string("default")
-		const pluginStore = strapi.store({ type: 'plugin', name: 'navigation' });
+		const pluginStore = await strapi.plugin('navigation').service('navigation').getPluginStore();
 		const config = await pluginStore.get({ key: 'config' });
 		const contentTypesNameFields = config.contentTypesNameFields;
 		Object.keys(contentTypesNameFields || {}).forEach(key => t.nonNull.list.string(key))


### PR DESCRIPTION
## Ticket

When migrating from older versions plugin's config did not have the correct structure. 

## Summary

Adds extra steps for each property of the plugin's config initialization process. If the property does not exist on an older version of the config it will be read from default and added to the new version.

## Test Plan

- Change configuration through the settings page
- Check if migration from an older version of the plugin is seamless 
- Check if the main flow works fine