### PR TITLE
Deleting a navigation item enabled for all locales

### DIFF
--- a/server/src/repositories/navigation.ts
+++ b/server/src/repositories/navigation.ts
@@ -101,13 +101,13 @@ export const getNavigationRepository = once((context: { strapi: Core.Strapi }) =
     }
   },
 
-  remove(navigation: Partial<Pick<NavigationDBSchema, 'documentId'>>) {
+  remove(navigation: Partial<Pick<NavigationDBSchema, 'documentId' | 'locale'>>) {
     const { masterModel } = getPluginModels(context);
 
     if (!navigation.documentId) {
       throw new NavigationError('Document id is required.');
     }
 
-    return context.strapi.documents(masterModel.uid).delete({ documentId: navigation.documentId });
+    return context.strapi.documents(masterModel.uid).delete({ documentId: navigation.documentId, locale: '*' });
   },
 }));

--- a/server/src/services/admin/admin.ts
+++ b/server/src/services/admin/admin.ts
@@ -423,8 +423,8 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
     if (detailsHaveChanged) {
       const newSlug = name
         ? await commonService.getSlug({
-            query: name,
-          })
+          query: name,
+        })
         : currentNavigation.slug;
 
       const allNavigations = await Promise.all(
@@ -519,7 +519,7 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
     });
 
     await cleanNavigationItems(allNavigations.map(({ id }: NavigationDBSchema) => id));
-    await navigationRepository.remove({ documentId: navigation.documentId });
+    await navigationRepository.remove({ documentId: navigation.documentId, locale: '*' });
 
     sendAuditLog(auditLog, 'onNavigationDeletion', {
       entity: navigationAsDTO,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/617

## Summary

Previously, it was not possible to delete a navigation item across all locales in the Strapi admin panel. This issue has been resolved, and now deleting an item will remove it from all locales.

## Test Plan

1. Create a navigation item.
2. Delete the newly created item.
3. Attempt to create a new item with the same name as the previously deleted item.