### PR TITLE
fix: url label changed to take correct value

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/components/PathField/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/components/PathField/index.tsx
@@ -10,7 +10,6 @@ import { generatePreviewPath } from '../../utils/properties';
 import { useConfig } from '../../../../hooks';
 import { NavigationItemFormSchema } from '../../utils/form';
 import { StrapiContentTypeItemSchema } from 'src/api/validators';
-import { isEmpty } from 'lodash';
 
 type PathFieldProps = {
   contentTypeItems: StrapiContentTypeItemSchema[] | undefined;
@@ -35,9 +34,9 @@ export const PathField: React.FC<PathFieldProps> = ({
     values.type === 'INTERNAL'
       ? values
       : {
-          related: undefined,
-          relatedType: undefined,
-        };
+        related: undefined,
+        relatedType: undefined,
+      };
 
   const pathDefault = generatePreviewPath({
     currentPath: values.path,
@@ -53,7 +52,15 @@ export const PathField: React.FC<PathFieldProps> = ({
 
   const disabled = !canUpdate || (values.autoSync && values.type === 'INTERNAL');
 
-  const [pathDefaultFieldsValue] = Object.values(configQuery.data?.pathDefaultFields ?? {}).flat();
+  const pathDefaultFieldsValue = internalValues.relatedType
+    ? (configQuery.data?.pathDefaultFields?.[internalValues.relatedType] ?? [])
+    : [];
+
+  const selectedEntity = contentTypeItems?.find(
+    ({ documentId }) => documentId === internalValues.related
+  );
+
+  const validPathFieldName = pathDefaultFieldsValue.find((field) => selectedEntity?.[field]);
 
   return (
     <Grid.Item alignItems="flex-start" key="title" col={12}>
@@ -65,13 +72,13 @@ export const PathField: React.FC<PathFieldProps> = ({
           formatMessage(getTrad(`popup.item.form.${pathSourceName}.placeholder`, 'e.g. Blog')),
           pathDefault
             ? formatMessage(getTrad('popup.item.form.type.external.description'), {
-                value: pathDefault,
-              })
+              value: pathDefault,
+            })
             : '',
           disabled
             ? formatMessage(getTrad('popup.item.form.type.internal.source'), {
-                value: !isEmpty(pathDefaultFieldsValue) ? pathDefaultFieldsValue : 'id',
-              })
+              value: validPathFieldName || 'id',
+            })
             : '',
         ].join(' ')}
       >

--- a/admin/src/translations/ca.ts
+++ b/admin/src/translations/ca.ts
@@ -315,7 +315,7 @@ const ca = {
         pathDefaultFields: {
           label: 'Champs par défaut du chemin',
           placeholder:
-            'Sélectionner au moins un ou laisser vide pour désactiver le remplissage du champ de chemin avec la valeur des attributs',
+            'Selecciona almenys un o deixa-ho buit perquè s’utilitzi Id com a valor per defecte.',
           hint: "La valeur de l'attribut sélectionné sera la valeur par défaut pour le chemin interne",
           empty: "Ce type de contenu n'a pas d'attributs appropriés",
         },

--- a/admin/src/translations/en.ts
+++ b/admin/src/translations/en.ts
@@ -316,7 +316,7 @@ const en = {
         pathDefaultFields: {
           label: 'Path default fields',
           placeholder:
-            'Select at least one or leave it empty to disable populating path field with attributes value',
+            'Select at least one or leave it empty to populate Id as default value',
           hint: 'Value of selected attribute will be a default value for internal path',
           empty: "This content type doesn't have any suitable attributes",
         },

--- a/admin/src/translations/es.ts
+++ b/admin/src/translations/es.ts
@@ -319,7 +319,7 @@ const en = {
         pathDefaultFields: {
           label: 'Campos predeterminados de ruta',
           placeholder:
-            'Selecciona al menos uno o déjalo vacío para deshabilitar la población de la ruta con valores de atributos',
+            'Selecciona al menos uno o déjalo vacío para que Id se use como valor predeterminado.',
           hint: 'El valor del atributo seleccionado será el valor predeterminado para la ruta interna',
           empty: 'Este tipo de contenido no tiene atributos adecuados',
         },

--- a/admin/src/translations/fr.ts
+++ b/admin/src/translations/fr.ts
@@ -319,7 +319,7 @@ const fr = {
         pathDefaultFields: {
           label: 'Champs par défaut du chemin',
           placeholder:
-            'Sélectionner au moins un ou laisser vide pour désactiver le remplissage du champ de chemin avec la valeur des attributs',
+            'Sélectionner au moins un ou laissez vide afin qu’Id soit utilisé comme valeur par défaut.',
           hint: "La valeur de l'attribut sélectionné sera la valeur par défaut pour le chemin interne",
           empty: "Ce type de contenu n'a pas d'attributs appropriés",
         },

--- a/admin/src/translations/tr.ts
+++ b/admin/src/translations/tr.ts
@@ -317,7 +317,7 @@ const tr = {
         pathDefaultFields: {
           label: 'Varsayılan yol alanları',
           placeholder:
-            'En az birini seçin veya yol alanını nitelik değeriyle doldurmayı devre dışı bırakın',
+            'En az birini seçin veya boş bırakın; varsayılan değer olarak Id kullanılır',
           hint: 'Seçilen nitelik değeri, dahili yol için varsayılan değer olacaktır',
           empty: 'Bu içerik türünde uygun nitelikler bulunmuyor',
         },


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/602

## Summary

This fix addresses changes made for https://github.com/VirtusLab/strapi-plugin-navigation/issues/602.

<img width="623" height="465" alt="Screenshot 2025-12-02 at 14 08 23" src="https://github.com/user-attachments/assets/292792fe-0e80-40e6-9861-fb647753e16e" />

The `URL based on` label has been modified to pull values from the corresponding page and to utilize the fallback in case the specified value is not available. 

## Test Plan

To verify that the label only takes values from the corresponding page:
1. Enable navigation for at least two pages.
2. Populate the Path Default Fields for both pages.
3. Check the URL label for the second navigation entry.

To ensure that the fallback functionality works:
1. Enable navigation for one of your pages.
2. Set some values in Path Default Fields in the settings page 
3. Make the first value undefined
4. Verify that the label takes the next available value.