### PR TITLE
feat: display friendly ct names

### DIFF
--- a/admin/src/api/validators.ts
+++ b/admin/src/api/validators.ts
@@ -115,7 +115,6 @@ export const configContentTypeSchema = z.object({
   collectionName: z.string(),
   contentTypeName: z.string(),
   label: z.string(),
-  labelSingular: z.string(),
   endpoint: z.string(),
   available: z.boolean(),
   visible: z.boolean(),

--- a/admin/src/pages/HomePage/components/NavigationItemForm/components/RelatedTypeField/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/components/RelatedTypeField/index.tsx
@@ -48,7 +48,7 @@ export const RelatedTypeField: React.FC<RelatedTypeFieldProps> = ({
         configQuery.data?.contentTypes.map((item) => ({
           key: item.uid,
           value: item.uid,
-          label: item.contentTypeName,
+          label: item.label,
         })),
         (item) => item.label
       ),

--- a/server/src/dtos/config.ts
+++ b/server/src/dtos/config.ts
@@ -13,10 +13,10 @@ export type ConfigContentTypeDTO = {
   relatedField: string | undefined;
   templateName: string | undefined;
   available: boolean | undefined;
-  labelSingular: string;
   endpoint: string;
   plugin: string | undefined;
   visible: boolean;
+  gqlTypeName: string;
 };
 
 export type NavigationPluginConfigDTO = Pick<


### PR DESCRIPTION
## Summary

This PR is a copy of the proposed enhancement by @jorrit to use a more user-friendly `displayName` of a content type instead of the raw name. The PR aligns with the newer version of Strapi, as well as fixing a few issues.
Linked PR: https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/pull/514
