### PR TITLE
fix-636: default select options

### DIFF
--- a/admin/src/components/TextArrayInput/index.tsx
+++ b/admin/src/components/TextArrayInput/index.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@strapi/design-system';
 import { isArray } from 'lodash';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Effect } from '../../types';
 
@@ -15,8 +15,9 @@ interface IProps {
 
 const TextArrayInput: React.FC<IProps> = ({ onChange, initialValue, ...props }) => {
   const [value, setValue] = useState(
-    isArray(initialValue) ? initialValue.reduce((acc, cur) => `${acc}${cur}; `, '') : ''
+    isArray(initialValue) ? initialValue.join(';') : ''
   );
+
   const handleOnChange = (event: { target: { value?: string } }) => {
     const newValue: string = event?.target.value ?? '';
     const valuesArray = newValue

--- a/admin/src/pages/SettingsPage/components/CustomFieldsPanel/CustomFieldForm/index.tsx
+++ b/admin/src/pages/SettingsPage/components/CustomFieldsPanel/CustomFieldForm/index.tsx
@@ -59,14 +59,18 @@ const CustomFieldForm: React.FC<ICustomFieldFormProps> = ({
 
   const { formatMessage } = useIntl();
 
-  const [formValue, setFormValue] = useState<NavigationItemCustomField>({
-    name: '',
-    label: '',
-    type: 'string',
-    required: false,
-    multi: false,
-    enabled: true,
-  });
+  const [formValue, setFormValue] = useState<NavigationItemCustomField>(
+    customField ? {
+      ...customField,
+    } : {
+      name: '',
+      label: '',
+      type: 'string',
+      required: false,
+      multi: false,
+      enabled: true,
+    },
+  );
   const [formError, setFormError] = useState<FormItemErrorSchema<NavigationItemCustomField>>();
 
   const { type } = formValue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "navigation",


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/636

## Summary

This PR ensures that when editing an additional field in the type `select`, we have an existing options inside the modal