### PR TITLE
chore: refresh lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -99,15 +99,15 @@
     "@apollo/utils.keyvaluecache" "^2.1.0"
     "@apollo/utils.logger" "^2.0.0"
 
-"@apollo/server@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@apollo/server/-/server-4.11.0.tgz#21c0f10ad805192a5485e58ed5c5b3dbe2243174"
-  integrity sha512-SWDvbbs0wl2zYhKG6aGLxwTJ72xpqp0awb2lotNpfezd9VcAvzaUizzKQqocephin2uMoaA8MguoyBmgtPzNWw==
+"@apollo/server@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@apollo/server/-/server-4.13.0.tgz#765e5ad6aaf3c901a678c3d9d63e354a12075e7c"
+  integrity sha512-t4GzaRiYIcPwYy40db6QjZzgvTr9ztDKBddykUXmBb2SVjswMKXbkaJ5nPeHqmT3awr9PAaZdCZdZhRj55I/8A==
   dependencies:
     "@apollo/cache-control-types" "^1.0.3"
     "@apollo/server-gateway-interface" "^1.1.1"
     "@apollo/usage-reporting-protobuf" "^4.1.1"
-    "@apollo/utils.createhash" "^2.0.0"
+    "@apollo/utils.createhash" "^2.0.2"
     "@apollo/utils.fetcher" "^2.0.0"
     "@apollo/utils.isnodelike" "^2.0.0"
     "@apollo/utils.keyvaluecache" "^2.1.0"
@@ -119,8 +119,9 @@
     "@types/express-serve-static-core" "^4.17.30"
     "@types/node-fetch" "^2.6.1"
     async-retry "^1.2.1"
+    content-type "^1.0.5"
     cors "^2.8.5"
-    express "^4.17.1"
+    express "^4.21.1"
     loglevel "^1.6.8"
     lru-cache "^7.10.1"
     negotiator "^0.6.3"
@@ -136,7 +137,7 @@
   dependencies:
     "@apollo/protobufjs" "1.2.7"
 
-"@apollo/utils.createhash@^2.0.0":
+"@apollo/utils.createhash@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@apollo/utils.createhash/-/utils.createhash-2.0.2.tgz#838767c83714354ab36892196b209e45d29745e6"
   integrity sha512-UkS3xqnVFLZ3JFpEmU/2cM2iKJotQXMoSTgxXsfQgXLC5gR1WaepoXagmYnPSA7Q/2cmnyTYK5OgAgoC4RULPg==
@@ -650,10 +651,10 @@
     hashery "^1.3.0"
     keyv "^5.5.5"
 
-"@casl/ability@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@casl/ability/-/ability-6.5.0.tgz#a151a7637886099b8ffe52a96601225004a5c157"
-  integrity sha512-3guc94ugr5ylZQIpJTLz0CDfwNi0mxKVECj1vJUPAvs+Lwunh/dcuUjwzc4MHM9D8JOYX0XUZMEPedpB3vIbOw==
+"@casl/ability@6.7.5":
+  version "6.7.5"
+  resolved "https://registry.yarnpkg.com/@casl/ability/-/ability-6.7.5.tgz#9468b210005ab5cbd7a5e030fb48d3a3720de92b"
+  integrity sha512-NaOHPi9JMn8Kesh+GRkjNKAYkl4q8qMFAlqw7w2yrE+cBQZSbV9GkBGKvgzs3CdzEc5Yl1cn3JwDxxbBN5gjog==
   dependencies:
     "@ucast/mongo2js" "^1.3.0"
 
@@ -1460,6 +1461,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1989,6 +1997,11 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/primitive@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+
 "@radix-ui/react-accordion@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-accordion/-/react-accordion-1.1.2.tgz#738441f7343e5142273cdef94d12054c3287966f"
@@ -2078,6 +2091,16 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-slot" "1.0.2"
 
+"@radix-ui/react-collection@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"
+  integrity sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -2085,12 +2108,22 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-compose-refs@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
 "@radix-ui/react-context@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
   integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
 
 "@radix-ui/react-dialog@1.0.5":
   version "1.0.5"
@@ -2119,6 +2152,11 @@
   integrity sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-direction@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
+  integrity sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==
 
 "@radix-ui/react-dismissable-layer@1.0.5":
   version "1.0.5"
@@ -2170,6 +2208,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-id@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-menu@2.0.6":
   version "2.0.6"
@@ -2260,6 +2305,13 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
 
+"@radix-ui/react-primitive@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.3"
+
 "@radix-ui/react-progress@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.0.3.tgz#8380272fdc64f15cbf263a294dea70a7d5d9b4fa"
@@ -2302,6 +2354,21 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-controllable-state" "1.0.1"
 
+"@radix-ui/react-roving-focus@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz#ef54384b7361afc6480dcf9907ef2fedb5080fd9"
+  integrity sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-scroll-area@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz#01160c6893f24a2ddb5aa399ae5b3ba84ad4d3cc"
@@ -2333,6 +2400,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-slot@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
 
 "@radix-ui/react-switch@1.0.3":
   version "1.0.3"
@@ -2377,6 +2451,19 @@
     "@radix-ui/react-toggle" "1.0.3"
     "@radix-ui/react-use-controllable-state" "1.0.1"
 
+"@radix-ui/react-toggle-group@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz#e513d6ffdb07509b400ab5b26f2523747c0d51c1"
+  integrity sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-toggle" "1.1.10"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-toggle@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz#aecb2945630d1dc5c512997556c57aba894e539e"
@@ -2386,6 +2473,15 @@
     "@radix-ui/primitive" "1.0.1"
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-toggle@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz#b04ba0f9609599df666fce5b2f38109a197f08cf"
+  integrity sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
 
 "@radix-ui/react-toolbar@1.0.4":
   version "1.0.4"
@@ -2427,6 +2523,11 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+
 "@radix-ui/react-use-controllable-state@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
@@ -2434,6 +2535,21 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-controllable-state@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
+  integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-effect-event@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
+  integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-use-escape-keydown@1.0.3":
   version "1.0.3"
@@ -2449,6 +2565,11 @@
   integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
 
 "@radix-ui/react-use-previous@1.0.1":
   version "1.0.1"
@@ -2764,26 +2885,26 @@
     cache-manager "^7.1.1"
     quick-lru "7.0.1"
 
-"@strapi/admin@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-5.33.4.tgz#819b7b22a1192762cb74525e8819ace13f497ca6"
-  integrity sha512-yfLIHovF0JoOmPgzg3+SZJAfimvLnKMvaFHOZC6wbmI17OfijdqvdlwjkIU6tUJvDpnZNKm/n+9cKtuWwDG8Zw==
+"@strapi/admin@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-5.37.0.tgz#63f12337ed5aa09ba0b308b984e4f0263c6918ac"
+  integrity sha512-mwKPqOb5ROtEjQBU2QH2FvWQcPrhEbmrFEQ9uewLx0q7sO1Fv75D0M43r8h5G+xTUHhrk80U9BWLJrzF/jPUyA==
   dependencies:
-    "@casl/ability" "6.5.0"
+    "@casl/ability" "6.7.5"
     "@internationalized/date" "3.5.4"
     "@radix-ui/react-context" "1.0.1"
     "@radix-ui/react-toolbar" "1.0.4"
     "@reduxjs/toolkit" "1.9.7"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/permissions" "5.33.4"
-    "@strapi/types" "5.33.4"
-    "@strapi/typescript-utils" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/permissions" "5.37.0"
+    "@strapi/types" "5.37.0"
+    "@strapi/typescript-utils" "5.37.0"
+    "@strapi/utils" "5.37.0"
     "@testing-library/dom" "10.4.1"
     "@testing-library/react" "16.3.0"
     "@testing-library/user-event" "14.6.1"
-    axios "1.12.2"
+    axios "1.13.5"
     bcryptjs "2.4.3"
     boxen "5.1.2"
     chalk "^4.1.2"
@@ -2807,14 +2928,14 @@
     koa-passport "6.0.0"
     koa-static "5.0.0"
     koa2-ratelimit "^1.1.3"
-    lodash "4.17.21"
+    lodash "4.17.23"
     motion "12.23.24"
     ora "5.4.1"
     p-map "4.0.0"
     passport-local "1.0.0"
     pluralize "8.0.0"
     punycode "2.3.1"
-    qs "6.14.1"
+    qs "6.14.2"
     react-dnd "16.0.1"
     react-dnd-html5-backend "16.0.1"
     react-intl "6.6.2"
@@ -2834,13 +2955,13 @@
     yup "0.32.9"
     zod "3.25.67"
 
-"@strapi/cloud-cli@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/cloud-cli/-/cloud-cli-5.33.4.tgz#78beb16ae55a5269c6b291541d5ab56e4b1c81f3"
-  integrity sha512-mOBXedIIJ7u9c4SIU24E+GWkqbfdiX1gc27xztsB7HFRsUTGiRW2Y5p+GBWRYh3DcJPFEiFSqBEpEsQat77IOg==
+"@strapi/cloud-cli@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/cloud-cli/-/cloud-cli-5.37.0.tgz#cac05c64ab7b73a243aa4672595be1726b36910a"
+  integrity sha512-W1boHSvmR9ncqzLjT+5YGjeoP1CBUtE832oaYwhKPkfMiSibzmBdc79gEISmPqtljS8Mx6yuiQdmMb5p2LRCgA==
   dependencies:
-    "@strapi/utils" "5.33.4"
-    axios "1.12.2"
+    "@strapi/utils" "5.37.0"
+    axios "1.13.5"
     boxen "5.1.2"
     chalk "4.1.2"
     cli-progress "3.12.0"
@@ -2851,19 +2972,19 @@
     inquirer "8.2.5"
     jsonwebtoken "9.0.0"
     jwks-rsa "3.1.0"
-    lodash "4.17.21"
-    minimatch "9.0.3"
+    lodash "4.17.23"
+    minimatch "10.2.2"
     open "8.4.0"
     ora "5.4.1"
     pkg-up "3.1.0"
-    tar "6.2.1"
+    tar "7.5.9"
     xdg-app-paths "8.3.0"
     yup "0.32.9"
 
-"@strapi/content-manager@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/content-manager/-/content-manager-5.33.4.tgz#a82a0d01739fac18834f91af2e5d92e785d751a2"
-  integrity sha512-uDeTbs5DMXLQ9798oa6RvqnNCiu6kj4VVtBTPMRAgi61uIvApaO80oVmAbvPAspxj8uQaEs726BUr4kujJft4w==
+"@strapi/content-manager@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/content-manager/-/content-manager-5.37.0.tgz#40459f4da6a69f9fcbc1fc25d38bca1d52db7210"
+  integrity sha512-qPOPZbUx9AxkAGpa3VHPZkpX1r/BRLL6EmnQ/DA8phZvzgmyPn1fXLIvwohLAIx2bu0Obe9/W3xJlF7Q1foZXA==
   dependencies:
     "@dnd-kit/core" "6.3.1"
     "@dnd-kit/sortable" "10.0.0"
@@ -2873,15 +2994,15 @@
     "@sindresorhus/slugify" "1.1.0"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/types" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/types" "5.37.0"
+    "@strapi/utils" "5.37.0"
     codemirror5 "npm:codemirror@^5.65.11"
     date-fns "2.30.0"
     fractional-indexing "3.2.0"
     highlight.js "^10.4.1"
     immer "9.0.21"
     koa "2.16.3"
-    lodash "4.17.21"
+    lodash "4.17.23"
     markdown-it "^13.0.2"
     markdown-it-abbr "^1.0.4"
     markdown-it-container "^3.0.0"
@@ -2893,7 +3014,7 @@
     markdown-it-sub "^1.0.0"
     markdown-it-sup "1.0.0"
     prismjs "1.30.0"
-    qs "6.14.1"
+    qs "6.14.2"
     react-dnd "16.0.1"
     react-dnd-html5-backend "16.0.1"
     react-helmet "^6.1.0"
@@ -2907,30 +3028,30 @@
     slate-react "0.98.3"
     yup "0.32.9"
 
-"@strapi/content-releases@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/content-releases/-/content-releases-5.33.4.tgz#6dc7b7f89fe752d981765104d38b5721bd71575b"
-  integrity sha512-xfmEGlSmslzLYD8OhkYmePgLzuqrwasQHH6+Z2pSOexbPyJly2KRLfx7X9ZLAxf6K8M9IT5+dz0gj2TKryn77g==
+"@strapi/content-releases@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/content-releases/-/content-releases-5.37.0.tgz#a63edf7e84cd47f51072694cc13449390c2e6318"
+  integrity sha512-3uC/BdYxGh/xIoNNH6+0yZU4qhQrrOa00mhSUpwsSzshZOz0/4+l5NmljD63xaj4E1NIRE/t+ur8v7jrJ2OTtA==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
-    "@strapi/database" "5.33.4"
+    "@strapi/database" "5.37.0"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/types" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/types" "5.37.0"
+    "@strapi/utils" "5.37.0"
     date-fns "2.30.0"
     date-fns-tz "2.0.1"
     formik "2.4.5"
-    lodash "4.17.21"
-    qs "6.14.1"
+    lodash "4.17.23"
+    qs "6.14.2"
     react-intl "6.6.2"
     react-redux "8.1.3"
     yup "0.32.9"
 
-"@strapi/content-type-builder@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/content-type-builder/-/content-type-builder-5.33.4.tgz#04188d655bacfece99ebe76c472f3a0472e9e186"
-  integrity sha512-nfsuMJOORE0NtLOpaSUTvBD9QlQoHPVvXwUtLv9IIhdU7F+VhZwtFw9xADdSdGCbTF23h6bo5kFcSs6SZKf9cA==
+"@strapi/content-type-builder@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/content-type-builder/-/content-type-builder-5.37.0.tgz#3fff0fa94b190925b977055e72a9c2a21b019184"
+  integrity sha512-zEVbfDscLgGhXGGyeMa9vKmZ3rKPlcRSLrGYAsiv/TJIeB/8wIxma+SRdadz1RqWWMcmMeZhLbu6PO6d5Tr7dg==
   dependencies:
     "@ai-sdk/react" "2.0.120"
     "@dnd-kit/core" "6.3.1"
@@ -2940,18 +3061,18 @@
     "@reduxjs/toolkit" "1.9.7"
     "@sindresorhus/slugify" "1.1.0"
     "@strapi/design-system" "2.1.2"
-    "@strapi/generators" "5.33.4"
+    "@strapi/generators" "5.37.0"
     "@strapi/icons" "2.1.2"
-    "@strapi/utils" "5.33.4"
+    "@strapi/utils" "5.37.0"
     ai "5.0.52"
     date-fns "2.30.0"
     fs-extra "11.2.0"
     immer "9.0.21"
     jszip "^3.10.1"
-    lodash "4.17.21"
+    lodash "4.17.23"
     micromatch "^4.0.8"
     pluralize "8.0.0"
-    qs "6.14.1"
+    qs "6.14.2"
     react-dropzone "14.3.8"
     react-intl "6.6.2"
     react-markdown "9.1.0"
@@ -2959,28 +3080,28 @@
     yup "0.32.9"
     zod "3.25.67"
 
-"@strapi/core@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/core/-/core-5.33.4.tgz#c6a170464c716ab9055bbf0b3f934979320abc94"
-  integrity sha512-U2I73h++THMHz5HRkb6g18VOHUS9smVNa+9V3gKj30MSx87jmrS8bynrE6ftAafTodTRSqhwk6GpIshisYFV8A==
+"@strapi/core@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/core/-/core-5.37.0.tgz#e9f3e3da94acf08a23df7e525b763a53100f8993"
+  integrity sha512-F+Rp2vrypotrQtd6K425jXF4nJ0BXZKhNIC5eyVreEleRmFRV+vHVP3bdLN1qoyertd+xFDRScGw5b+/KHa6aw==
   dependencies:
     "@koa/cors" "5.0.0"
     "@koa/router" "12.0.2"
     "@paralleldrive/cuid2" "2.2.2"
-    "@strapi/admin" "5.33.4"
-    "@strapi/database" "5.33.4"
-    "@strapi/generators" "5.33.4"
-    "@strapi/logger" "5.33.4"
-    "@strapi/permissions" "5.33.4"
-    "@strapi/types" "5.33.4"
-    "@strapi/typescript-utils" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/admin" "5.37.0"
+    "@strapi/database" "5.37.0"
+    "@strapi/generators" "5.37.0"
+    "@strapi/logger" "5.37.0"
+    "@strapi/permissions" "5.37.0"
+    "@strapi/types" "5.37.0"
+    "@strapi/typescript-utils" "5.37.0"
+    "@strapi/utils" "5.37.0"
     "@vercel/stega" "0.1.2"
     bcryptjs "2.4.3"
     boxen "5.1.2"
     chalk "4.1.2"
     ci-info "4.0.0"
-    cli-table3 "0.6.2"
+    cli-table3 "0.6.5"
     commander "8.3.0"
     configstore "5.0.1"
     copyfiles "2.4.1"
@@ -3005,14 +3126,14 @@
     koa-ip "^2.1.3"
     koa-session "6.4.0"
     koa-static "5.0.0"
-    lodash "4.17.21"
+    lodash "4.17.23"
     mime-types "2.1.35"
     node-schedule "2.1.1"
     open "8.4.0"
     ora "5.4.1"
     package-json "7.0.0"
     pkg-up "3.1.0"
-    qs "6.14.1"
+    qs "6.14.2"
     resolve.exports "2.0.2"
     semver "7.5.4"
     statuses "2.0.1"
@@ -3021,42 +3142,42 @@
     yup "0.32.9"
     zod "3.25.67"
 
-"@strapi/data-transfer@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/data-transfer/-/data-transfer-5.33.4.tgz#797c1b693cfab6670eed019a015ddf3488e184f6"
-  integrity sha512-tnXmQ7bPfoVVP5awCi3JABKElPEK1o1RmxFjV4gxlNerdGFOudggIwoxIrOLMAHHaWJsUqfNyKaGLN08dzpoBA==
+"@strapi/data-transfer@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/data-transfer/-/data-transfer-5.37.0.tgz#03d556fb8f98f5716b53075874a7744536b5de15"
+  integrity sha512-LZ/bF9VElyi2yloCx9YOfjDD3/XWgSVjM1DKLKNWDvvXCtMkOPUqReBt0T3h4tHYw08O/nxkysdCPe/2XhlStg==
   dependencies:
-    "@strapi/logger" "5.33.4"
-    "@strapi/types" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/logger" "5.37.0"
+    "@strapi/types" "5.37.0"
+    "@strapi/utils" "5.37.0"
     chalk "4.1.2"
     cli-table3 "0.6.5"
     commander "8.3.0"
     fs-extra "11.2.0"
     inquirer "8.2.5"
-    lodash "4.17.21"
+    lodash "4.17.23"
     ora "5.4.1"
     resolve-cwd "3.0.0"
     semver "7.5.4"
     stream-chain "2.2.5"
     stream-json "1.8.0"
-    tar "6.2.1"
+    tar "7.5.9"
     tar-stream "2.2.0"
     ws "8.17.1"
 
-"@strapi/database@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-5.33.4.tgz#35e268da577e618a9dbbf363801882e50413c5a7"
-  integrity sha512-M/LJRsmiElbfKdSwHsJCKdM1uvYH/Ky+olyRL3gOyZ7Fa7TRfWe630c5fHKPltl7OtPZO4PiaQYbi3je+UN00Q==
+"@strapi/database@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-5.37.0.tgz#cf27f938ea847ba10cc26f7307f80e3a338346c5"
+  integrity sha512-E9iYGuk2xMtk+sjcXrqvzRH5EqZ9DG/CoNXILKTxAYomMpDZBq8HudV+Dr1zDyJC8qtCSgWhvp9rjb7xd4kF0w==
   dependencies:
     "@paralleldrive/cuid2" "2.2.2"
-    "@strapi/utils" "5.33.4"
-    ajv "8.16.0"
+    "@strapi/utils" "5.37.0"
+    ajv "8.18.0"
     date-fns "2.30.0"
     debug "4.3.4"
     fs-extra "11.2.0"
     knex "3.0.1"
-    lodash "4.17.21"
+    lodash "4.17.23"
     semver "7.5.4"
     umzug "3.8.1"
 
@@ -3091,50 +3212,50 @@
     lodash "4.17.21"
     react-remove-scroll "2.5.10"
 
-"@strapi/email@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/email/-/email-5.33.4.tgz#84c01b8a4bd58e281845d85df0cf8c59e949aaec"
-  integrity sha512-q4ijlwrodPFAwaK3CbS5r3oyhmkVyUM2b1grtRJsCSs7EWkKM2mygMECEM7Tp6ao3xxgjpE39D6KenDKHDZ/Ww==
+"@strapi/email@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/email/-/email-5.37.0.tgz#c148b10604805fedd1ff026b98e262137df2eee6"
+  integrity sha512-bzWtX3XUKf5I8z/Fft4LLQdWOBygthQVbLRpdzPYay7Nwn0iLdrbRRWXzmCLo92q+GNwNtHIY9/T5BjBMVhGCQ==
   dependencies:
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/provider-email-sendmail" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/provider-email-sendmail" "5.37.0"
+    "@strapi/utils" "5.37.0"
     koa2-ratelimit "^1.1.3"
-    lodash "4.17.21"
+    lodash "4.17.23"
     react-intl "6.6.2"
     react-query "3.39.3"
     yup "0.32.9"
     zod "3.25.67"
 
-"@strapi/generators@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-5.33.4.tgz#500021b36d1e9e38287c62d106f8cbe441f1669d"
-  integrity sha512-zsGdGsznfFbCfE5mE+CogDxOnI4h/TxZJKXSOeBP7V9j2wgd1JXJFDPWzUUMePzZ0TFbuki7LYGhXwPRnycqGQ==
+"@strapi/generators@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-5.37.0.tgz#a30c32df0a77521db5aacdb312ae81c74660a266"
+  integrity sha512-IXrcDlbrCik1MP3DqzlArPEtGUh+4U5on88Rx7Nigs7XpBng36aB/KY0jU4uGCQUbDrdE7yLqo0V4CGu61N04w==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/typescript-utils" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/typescript-utils" "5.37.0"
+    "@strapi/utils" "5.37.0"
     chalk "4.1.2"
     copyfiles "2.4.1"
     fs-extra "11.2.0"
     handlebars "4.7.7"
     jscodeshift "17.3.0"
-    lodash "4.17.21"
+    lodash "4.17.23"
     plop "4.0.1"
     pluralize "8.0.0"
 
-"@strapi/i18n@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/i18n/-/i18n-5.33.4.tgz#8e8e5b55d0d448d260ca317e51b44c1a02842178"
-  integrity sha512-KCe50Yb6u5l0xOs8dLZ8VYPI0aYPxnQaXIDkixHtibY9geE2FG7NB0AM6DWBgGhJ0wGPt/xQXPjoI0fNv9hI/g==
+"@strapi/i18n@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/i18n/-/i18n-5.37.0.tgz#272a4ea3ad3e5e19b3b7885a8ad26a484d20f35a"
+  integrity sha512-uPjfcjFgBA15DWRyRSf5pSmJOkpdstRjXSWSizKf+7gQ55bh2s+rUEeKOv2bZFV0UeqVe8jf9ceFUvurQWushA==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/utils" "5.33.4"
-    lodash "4.17.21"
-    qs "6.14.1"
+    "@strapi/utils" "5.37.0"
+    lodash "4.17.23"
+    qs "6.14.2"
     react-intl "6.6.2"
     react-redux "8.1.3"
     yup "0.32.9"
@@ -3145,18 +3266,18 @@
   resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-2.1.2.tgz#019cd6b62bd18f1827fad48dce15733892440013"
   integrity sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==
 
-"@strapi/logger@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-5.33.4.tgz#dd8267c3022262094bfe8ccbf70732749590c749"
-  integrity sha512-l22hbyJLmU8wICIuHDnvi+YT7y2PRU8c/aHRw4OijRru0ge3sQ0dKn4cb415lLR8yiOLwI4iczh98UawZyvW0g==
+"@strapi/logger@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-5.37.0.tgz#e2bb295d2d51b75c458a59b308f1f09b9b2f989e"
+  integrity sha512-6YFU6UdRO5ZJ+OSUwy6Y3hoGLbK6JAZTSlHFap8rZa0HdXBckPSk4G1jqFL/eMeBtY1azlidBW2q5as9hg6Yhg==
   dependencies:
-    lodash "4.17.21"
+    lodash "4.17.23"
     winston "3.10.0"
 
-"@strapi/openapi@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/openapi/-/openapi-5.33.4.tgz#114b0088d6159a09e46918de3ea0413e1f4fc6ab"
-  integrity sha512-l498PZfr5bAvRAT3A60+D+do6gk3wxSz6j6lxt1CKwTWcjZoHCyZqZdr5UzW2fIYTWhrqrFyR/nDFPdCqwyCOg==
+"@strapi/openapi@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/openapi/-/openapi-5.37.0.tgz#66bcf9b49b2ef5eb035ddae377e31940bc92f25e"
+  integrity sha512-XclQZpwP39h9xD4HR6kqKUOa0Vmnaf9KEnaQWsBIvbYdyXjjNYQQbP782Y+jdpH4ZY/SpCqNbgG2Kg8WLF9iAw==
   dependencies:
     debug "4.3.4"
     openapi-types "12.1.3"
@@ -3189,65 +3310,65 @@
     vite "5.4.21"
     yup "0.32.9"
 
-"@strapi/permissions@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/permissions/-/permissions-5.33.4.tgz#9392ff21a3db3337576bc6b6d28d3241e5581a42"
-  integrity sha512-KvaZ2aNnnAMCW4kDZEV0HF5aoN9h0hu9pVqgzeJghv5t1ALKCLIMAW+q8U//2uVtBxgXhvRQkD7kShT2uR3s3g==
+"@strapi/permissions@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/permissions/-/permissions-5.37.0.tgz#010cc6557e142fadb98dda39125c37299625e98e"
+  integrity sha512-iKQMSs8XdCOUJRFzWU/OjdAOyTus2yjdXCxVzYF9nVjKif57HPtXn9amsqvArkArDtvNMxCQ+iHMe0IUyhhdnw==
   dependencies:
-    "@casl/ability" "6.5.0"
-    "@strapi/utils" "5.33.4"
-    lodash "4.17.21"
-    qs "6.14.1"
+    "@casl/ability" "6.7.5"
+    "@strapi/utils" "5.37.0"
+    lodash "4.17.23"
+    qs "6.14.2"
     sift "16.0.1"
 
-"@strapi/plugin-graphql@^5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-5.33.4.tgz#a185a1c45151373f52f85d773f579109306bcdea"
-  integrity sha512-0mzm9ayfj1bhcpXXkYa5ibZjR4I+7qGwsrUpOsy2GHgPNFvzXQzu474pi1fMgZUJyz4/a40/vqyThhThu3Foqw==
+"@strapi/plugin-graphql@^5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-5.37.0.tgz#276f09419eaac44dc0e0cb8aae4841efc7bab42e"
+  integrity sha512-Xeml7vJlievze7mRw1tdnRJnlHais916Kyt+JLlTE8TMNp4+8KdiIKIVACa/8ZkFA29Tph/jcn5GVbp8An4b1Q==
   dependencies:
-    "@apollo/server" "4.11.0"
+    "@apollo/server" "4.13.0"
     "@as-integrations/koa" "1.1.1"
     "@graphql-tools/schema" "10.0.3"
     "@graphql-tools/utils" "^10.1.3"
     "@koa/cors" "5.0.0"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/utils" "5.33.4"
+    "@strapi/utils" "5.37.0"
     graphql "^16.8.1"
     graphql-depth-limit "^1.1.0"
     graphql-playground-middleware-koa "^1.6.21"
     graphql-scalars "1.22.2"
     koa-bodyparser "4.4.1"
     koa-compose "^4.1.0"
-    lodash "4.17.21"
+    lodash "4.17.23"
     nexus "1.3.0"
     pluralize "8.0.0"
 
-"@strapi/provider-email-sendmail@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.33.4.tgz#c1b62c3f5cd804ca020fd7d1847a1661620e2eee"
-  integrity sha512-6dw8T1g4q6xLeFQmM8DNmIeEW6M9iEw+ptWKVuWKxm8q1l7I4FsfpbXz//QHxG48sGX3muinpXZWYTCVe0EDFA==
+"@strapi/provider-email-sendmail@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.37.0.tgz#cabc1e460743a4722f041806242c03e1e9a31127"
+  integrity sha512-BPUna/WBq0K5n4bz+wzq8V6mfNzFd0VjmHpXre9w/9AJ26ZTKzOap3BP0z7ysK3kp/uCkL+FJzEuaH3W2qOhtA==
   dependencies:
-    "@strapi/utils" "5.33.4"
+    "@strapi/utils" "5.37.0"
     sendmail "^1.6.1"
 
-"@strapi/provider-upload-local@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-5.33.4.tgz#95372f8d8342386cd805e16e787715067add7dc5"
-  integrity sha512-QClJYABNILj8lxPM6TE7hUnCrjxr0qXWo8RvUuDdoFWHoLrOctja40AkwJx+fFzFoR7YiWGNMcTahEiI8lipww==
+"@strapi/provider-upload-local@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-5.37.0.tgz#c5799bde55fb0f5aa78399d32a04a3238532bee6"
+  integrity sha512-hkGQbKOW5Qnl85pmV34zRgB9fy4gCtVCHfZg92WQ7/3mjdHsiwdTJ11syIuSawl61deVanFVNEhQf7POqYHFFw==
   dependencies:
-    "@strapi/utils" "5.33.4"
+    "@strapi/utils" "5.37.0"
     fs-extra "11.2.0"
 
-"@strapi/review-workflows@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/review-workflows/-/review-workflows-5.33.4.tgz#fb506389be600d88d71f6c571123e437730c3ece"
-  integrity sha512-JLZOUBgQn+oLiv4EQMVLtK7MioHpfIMyBJK0AOIFR+pBfVqwOHxVHELU79YjYZtel4ZtyD+5MDxmjKGgk7B1gA==
+"@strapi/review-workflows@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/review-workflows/-/review-workflows-5.37.0.tgz#d2ed55bdbe64756e605a0efdd7e2ec216159737a"
+  integrity sha512-BiZqdpbtO3DfC6SNjyZqySwFU7AgDLVaSP3iHb6fzqD3L0oZtmcXHcsBnjkKP2ToI2MYOnBfK4IPh965i3080Q==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/utils" "5.33.4"
+    "@strapi/utils" "5.37.0"
     fractional-indexing "3.2.0"
     react-dnd "16.0.1"
     react-dnd-html5-backend "16.0.1"
@@ -3278,31 +3399,31 @@
     typescript "5.4.4"
     yup "0.32.9"
 
-"@strapi/strapi@^5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-5.33.4.tgz#33952a1becd22de273c4d21a923781e571bf4a04"
-  integrity sha512-rMGciJ8Lgz08cQK07Se/c2yLkCA+1Dso7vLDOFpz321ApDKMDghYizIbXKGgRV5EgOiji0/lHbMbhWIG3mC1xA==
+"@strapi/strapi@^5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-5.37.0.tgz#92c0ef242e6083d0cbcc912660f457f396141c98"
+  integrity sha512-ElYXSdfhUQCYRGWE4Fy65V57RORxyTSpnBSEbEhGrl+oQyJALiM/ppfP6iEHxImOCvtfHqHo6mtRZBOdPx1QFg==
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin" "0.5.15"
-    "@strapi/admin" "5.33.4"
-    "@strapi/cloud-cli" "5.33.4"
-    "@strapi/content-manager" "5.33.4"
-    "@strapi/content-releases" "5.33.4"
-    "@strapi/content-type-builder" "5.33.4"
-    "@strapi/core" "5.33.4"
-    "@strapi/data-transfer" "5.33.4"
-    "@strapi/database" "5.33.4"
-    "@strapi/email" "5.33.4"
-    "@strapi/generators" "5.33.4"
-    "@strapi/i18n" "5.33.4"
-    "@strapi/logger" "5.33.4"
-    "@strapi/openapi" "5.33.4"
-    "@strapi/permissions" "5.33.4"
-    "@strapi/review-workflows" "5.33.4"
-    "@strapi/types" "5.33.4"
-    "@strapi/typescript-utils" "5.33.4"
-    "@strapi/upload" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/admin" "5.37.0"
+    "@strapi/cloud-cli" "5.37.0"
+    "@strapi/content-manager" "5.37.0"
+    "@strapi/content-releases" "5.37.0"
+    "@strapi/content-type-builder" "5.37.0"
+    "@strapi/core" "5.37.0"
+    "@strapi/data-transfer" "5.37.0"
+    "@strapi/database" "5.37.0"
+    "@strapi/email" "5.37.0"
+    "@strapi/generators" "5.37.0"
+    "@strapi/i18n" "5.37.0"
+    "@strapi/logger" "5.37.0"
+    "@strapi/openapi" "5.37.0"
+    "@strapi/permissions" "5.37.0"
+    "@strapi/review-workflows" "5.37.0"
+    "@strapi/types" "5.37.0"
+    "@strapi/typescript-utils" "5.37.0"
+    "@strapi/upload" "5.37.0"
+    "@strapi/utils" "5.37.0"
     "@types/nodemon" "1.19.6"
     "@vitejs/plugin-react-swc" "3.6.0"
     boxen "5.1.2"
@@ -3310,7 +3431,7 @@
     browserslist-to-esbuild "1.2.0"
     chalk "4.1.2"
     chokidar "3.6.0"
-    ci-info "3.8.0"
+    ci-info "4.0.0"
     cli-progress "3.12.0"
     cli-table3 "0.6.5"
     commander "8.3.0"
@@ -3327,7 +3448,7 @@
     git-url-parse "14.0.0"
     html-webpack-plugin "5.6.0"
     inquirer "8.2.5"
-    lodash "4.17.21"
+    lodash "4.17.23"
     mini-css-extract-plugin "2.7.7"
     nodemon "3.0.2"
     ora "5.4.1"
@@ -3348,18 +3469,18 @@
     yalc "1.0.0-pre.53"
     yup "0.32.9"
 
-"@strapi/types@5.33.4", "@strapi/types@^5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/types/-/types-5.33.4.tgz#75ff5ee6d0924f57a2b9473fe51e56f1a56bbb0e"
-  integrity sha512-c3UqdrkMpr7c2htB0XtYFTBqtv10Cbv4jdJeTLcQzEplhJHnVXjA2+aMouZ0b7lLivGxfT03cMf0f4Nll5GrgA==
+"@strapi/types@5.37.0", "@strapi/types@^5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/types/-/types-5.37.0.tgz#037ad7d08e603335e96b8f157a31375a4740bc18"
+  integrity sha512-pjVz9bjp/2J5dbd9ECVoKYr03q3SEV1APkzjlvOUV9K0+aNdGoUegaIHdSbG/XLwGdAy8CV049YykAyhY5abNw==
   dependencies:
-    "@casl/ability" "6.5.0"
+    "@casl/ability" "6.7.5"
     "@koa/cors" "5.0.0"
     "@koa/router" "12.0.2"
-    "@strapi/database" "5.33.4"
-    "@strapi/logger" "5.33.4"
-    "@strapi/permissions" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/database" "5.37.0"
+    "@strapi/logger" "5.37.0"
+    "@strapi/permissions" "5.37.0"
+    "@strapi/utils" "5.37.0"
     commander "8.3.0"
     json-logic-js "2.0.5"
     koa "2.16.3"
@@ -3370,15 +3491,15 @@
     typedoc-plugin-markdown "3.17.1"
     zod "3.25.67"
 
-"@strapi/typescript-utils@5.33.4", "@strapi/typescript-utils@^5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/typescript-utils/-/typescript-utils-5.33.4.tgz#172e88d79a882562fc11df552fef8679e1a97b89"
-  integrity sha512-47t+tOeYL1pLaD7ZCY2YJyQ+MAkSOUV3iUBhlHc4TwIDc0NRd7csjfxhbjVld9t/bJ26oizSf9IICWDcVSwNyg==
+"@strapi/typescript-utils@5.37.0", "@strapi/typescript-utils@^5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/typescript-utils/-/typescript-utils-5.37.0.tgz#fb901aedeecfaa27a001267c68d34f0bdbccbb16"
+  integrity sha512-6MXLBdqgCXqw7/ojvYgYApYPhGMHZwI9f+n6WxqlGRuqWUEFErOXFTfUNrkhJIYH+Nmo3PuDAlNPIDyknA05Mw==
   dependencies:
     chalk "4.1.2"
     cli-table3 "0.6.5"
     fs-extra "11.2.0"
-    lodash "4.17.21"
+    lodash "4.17.23"
     prettier "3.3.3"
     typescript "5.4.4"
 
@@ -3409,17 +3530,20 @@
     aria-hidden "1.2.4"
     react-remove-scroll "2.5.10"
 
-"@strapi/upload@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/upload/-/upload-5.33.4.tgz#6d614897e4da5254048cf007dd2671235b52ad21"
-  integrity sha512-aE2KM1w2AiOouw/J5MkVyhBdjptrbMC2D8o1OOEgC0MT3881SRHezYBNP6z98EtnfHi1iVLNcxwvXhH/kq3s0Q==
+"@strapi/upload@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/upload/-/upload-5.37.0.tgz#ae465efbfe51219bb926a75e98583011652f9419"
+  integrity sha512-+XuCD2nESUQtdvce/bvyJ835+anb9qIpFpRmco+1iCwfF9oU2+JIVJDJcpNOv9OnV0x13N7O5M2gfTT3I4eJMg==
   dependencies:
     "@mux/mux-player-react" "3.1.0"
+    "@radix-ui/react-dialog" "1.0.5"
+    "@radix-ui/react-toggle-group" "1.1.11"
     "@reduxjs/toolkit" "1.9.7"
+    "@strapi/database" "5.37.0"
     "@strapi/design-system" "2.1.2"
     "@strapi/icons" "2.1.2"
-    "@strapi/provider-upload-local" "5.33.4"
-    "@strapi/utils" "5.33.4"
+    "@strapi/provider-upload-local" "5.37.0"
+    "@strapi/utils" "5.37.0"
     byte-size "8.1.1"
     cropperjs "1.6.1"
     date-fns "2.30.0"
@@ -3429,10 +3553,10 @@
     immer "9.0.21"
     koa-range "0.3.0"
     koa-static "5.0.0"
-    lodash "4.17.21"
+    lodash "4.17.23"
     mime-types "2.1.35"
     prop-types "^15.8.1"
-    qs "6.14.1"
+    qs "6.14.2"
     react-dnd "16.0.1"
     react-intl "6.6.2"
     react-query "3.39.3"
@@ -3442,19 +3566,19 @@
     yup "0.32.9"
     zod "3.25.67"
 
-"@strapi/utils@5.33.4":
-  version "5.33.4"
-  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-5.33.4.tgz#cdd7f46ce9729656c71de0eb7296ac12308b007d"
-  integrity sha512-O/Zs3ywRX/bgGyIHCwWI2PnUF1qq8CovYaulwm8cEXPvS//1fCPn70bLorQqwMkDJ69oDOHS7xtsHJKMgierlQ==
+"@strapi/utils@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-5.37.0.tgz#7a24d6e61893221c6147e38b257e0fe26044c36a"
+  integrity sha512-PxZZrpF2xTxR53x5bWVdLhiTu4AzhJjyIRVFn97xqea+JplNeipGSvkoe3rAWAZF12E01qv465omY0Bw6Boamg==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
     date-fns "2.30.0"
     execa "5.1.1"
     http-errors "2.0.0"
-    lodash "4.17.21"
+    lodash "4.17.23"
     node-machine-id "1.1.12"
     p-map "4.0.0"
-    preferred-pm "3.1.2"
+    preferred-pm "3.1.3"
     yup "0.32.9"
     zod "3.25.67"
 
@@ -4551,15 +4675,15 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@8.16.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.16.0.tgz#22e2a92b94f005f7e0f9c9d39652ef0b8f6f0cb4"
-  integrity sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==
+ajv@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
   dependencies:
     fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
-    uri-js "^4.4.1"
 
 ajv@^6.12.5:
   version "6.12.6"
@@ -4764,13 +4888,13 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
-  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
+axios@1.13.5:
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
+  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
     proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
@@ -4854,6 +4978,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -4950,6 +5079,13 @@ brace-expansion@^2.0.1:
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.3.tgz#6a9c6c268f85b53959ec527aeafe0f7300258eef"
+  integrity sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
@@ -5229,20 +5365,15 @@ chokidar@4.0.1:
   dependencies:
     readdirp "^4.0.1"
 
-chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chrome-trace-event@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz#05bffd7ff928465093314708c93bdfa9bd1f0f5b"
   integrity sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==
-
-ci-info@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
-  integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
 ci-info@4.0.0:
   version "4.0.0"
@@ -5301,15 +5432,6 @@ cli-spinners@^2.5.0, cli-spinners@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
   integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
-
-cli-table3@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
-  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
-  dependencies:
-    string-width "^4.2.0"
-  optionalDependencies:
-    "@colors/colors" "1.5.0"
 
 cli-table3@0.6.5:
   version "0.6.5"
@@ -6505,7 +6627,7 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-express@^4.17.1:
+express@^4.21.1:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.22.1.tgz#1de23a09745a4fffdb39247b344bb5eaff382069"
   integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
@@ -6755,7 +6877,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.15.6, follow-redirects@^1.15.9:
+follow-redirects@^1.15.11, follow-redirects@^1.15.9:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
@@ -6805,7 +6927,7 @@ fork-ts-checker-webpack-plugin@8.0.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@^4.0.4:
+form-data@^4.0.4, form-data@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -6904,13 +7026,6 @@ fs-extra@~11.3.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
-
-fs-minipass@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
-  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
-  dependencies:
-    minipass "^3.0.0"
 
 fs-monkey@^1.0.4:
   version "1.1.0"
@@ -9025,7 +9140,7 @@ lodash@4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@4.17.23, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
@@ -9716,12 +9831,12 @@ mini-css-extract-plugin@2.7.7:
   dependencies:
     schema-utils "^4.0.0"
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+minimatch@10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.2.tgz#361603ee323cfb83496fea2ae17cc44ea4e1f99f"
+  integrity sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^5.0.2"
 
 minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -9742,32 +9857,24 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@^3.0.0:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
-  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
-  dependencies:
-    yallist "^4.0.0"
-
-minipass@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
-  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
-
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-minizlib@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
-  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
+minipass@^7.0.4:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
-mkdirp@^1.0.3, mkdirp@^1.0.4:
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
+
+mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -10622,10 +10729,10 @@ postcss@^8.3.11, postcss@^8.4.33, postcss@^8.4.43:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
-preferred-pm@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.1.2.tgz#aedb70550734a574dffcbf2ce82642bd1753bdd6"
-  integrity sha512-nk7dKrcW8hfCZ4H6klWcdRknBOXWzNQByJ0oJyX97BOupsYD+FzLS4hflgEu/uPUEHZCuRfMxzCBsuWd7OzT8Q==
+preferred-pm@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.1.3.tgz#4125ea5154603136c3b6444e5f5c94ecf90e4916"
+  integrity sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==
   dependencies:
     find-up "^5.0.0"
     find-yarn-workspace-root2 "1.2.16"
@@ -10776,7 +10883,14 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-qs@6.14.1, qs@^6.11.0, qs@^6.5.2, qs@~6.14.0:
+qs@6.14.2:
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
+  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+  dependencies:
+    side-channel "^1.1.0"
+
+qs@^6.11.0, qs@^6.5.2, qs@~6.14.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
@@ -12257,17 +12371,16 @@ tar-stream@2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
-  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+tar@7.5.9:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.9.tgz#817ac12a54bc4362c51340875b8985d7dc9724b8"
+  integrity sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==
   dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^5.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
 
 tarn@^3.0.2:
   version "3.0.2"
@@ -13279,6 +13392,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml@^1.10.0:
   version "1.10.2"


### PR DESCRIPTION
## Summary

This PR refreshes `yarn.lockfile`. This should remove dependabot alerts.