### PR TITLE
fix: enable path change when read fields from related enable

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/components/PathField/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/components/PathField/index.tsx
@@ -50,18 +50,6 @@ export const PathField: React.FC<PathFieldProps> = ({
     isSingleSelected,
   });
 
-  const disabled = !canUpdate || (values.autoSync && values.type === 'INTERNAL');
-
-  const pathDefaultFieldsValue = internalValues.relatedType
-    ? (configQuery.data?.pathDefaultFields?.[internalValues.relatedType] ?? [])
-    : [];
-
-  const selectedEntity = contentTypeItems?.find(
-    ({ documentId }) => documentId === internalValues.related
-  );
-
-  const validPathFieldName = pathDefaultFieldsValue.find((field) => selectedEntity?.[field]);
-
   return (
     <Grid.Item alignItems="flex-start" key="title" col={12}>
       <Field
@@ -75,15 +63,10 @@ export const PathField: React.FC<PathFieldProps> = ({
                 value: pathDefault,
               })
             : '',
-          disabled
-            ? formatMessage(getTrad('popup.item.form.type.internal.source'), {
-                value: validPathFieldName || 'id',
-              })
-            : '',
         ].join(' ')}
       >
         <TextInput
-          disabled={disabled}
+          disabled={!canUpdate}
           name={pathSourceName}
           onChange={(eventOrPath: FormChangeEvent, value?: any) =>
             handleChange(eventOrPath, value, onChange)

--- a/admin/src/pages/HomePage/components/NavigationItemForm/components/RelatedEntityField/hooks.ts
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/components/RelatedEntityField/hooks.ts
@@ -25,7 +25,7 @@ export const useChangeFieldsFromRelated = (
 
     const { contentTypesNameFields, pathDefaultFields } = configQuery.data;
 
-    const nextPath = (
+    const nextPath = values.path ? values.path : (
       pathDefaultFields[values.relatedType]?.reduce<string | undefined>((acc, field) => {
         return acc ? acc : relatedItem?.[field];
       }, undefined) || relatedItem.id


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/638

## Summary

This PR enabled editing of the path input even in the case where the `read fields from related` option is enabled
