### PR TITLE
feat: add plugin version to the settings page

### DIFF
--- a/admin/src/pages/SettingsPage/index.tsx
+++ b/admin/src/pages/SettingsPage/index.tsx
@@ -148,7 +148,7 @@ const Inner = () => {
         <Layouts.Header
           title={formatMessage(getTrad('pages.settings.header.title'))}
           subtitle={
-            <Flex direction="row" gap={3} alignItems="center">
+            <Flex direction="row" gap={3} alignItems="center" justifyContent="space-between">
               <Typography variant="epsilon" textColor="neutral600" tag="p">
                 {formatMessage(getTrad('pages.settings.header.description'))}
               </Typography>


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/656

## Summary
Added plugin version to the settings page

<img width="1150" height="98" alt="image" src="https://github.com/user-attachments/assets/82daf46b-9a70-4e7b-8db4-e209cd37dcb0" />

