### PR TITLE
fix: normalize parent.related in flattenRelated recursively

### DIFF
--- a/server/src/repositories/navigation-item.ts
+++ b/server/src/repositories/navigation-item.ts
@@ -135,7 +135,8 @@ export const removeSensitiveFields = ({
     : undefined,
 });
 
-export const flattenRelated = ({ related, ...item }: any) => ({
+export const flattenRelated = ({ related, parent, ...item }: any): NavigationItemDBSchema => ({
   ...item,
+  parent: parent ? flattenRelated(parent) : parent,
   related: related?.[0],
 });

--- a/server/tests/repositories/navigation.test.ts
+++ b/server/tests/repositories/navigation.test.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
 import { Core } from '@strapi/strapi';
-import { asProxy } from '../utils';
 import { getNavigationRepository } from '../../src/repositories';
 import { getPluginModels } from '../../src/utils';
+import { asProxy } from '../utils';
 
 jest.mock('../../src/utils', () => ({
   ...jest.requireActual('../../src/utils'),
@@ -158,6 +158,60 @@ describe('Navigation', () => {
           });
           expect(mockCreate).not.toHaveBeenCalled();
           expect(result).toBeDefined();
+        });
+        it('should handle parent.related as array (bug reproduction)', async () => {
+          // Given - Strapi returns parent.related as an array (morphToMany behavior)
+          const mockData = [
+            getMockNavigationData({
+              items: [
+                {
+                  id: 1,
+                  documentId: 'item-1',
+                  title: 'Parent Item',
+                  type: 'INTERNAL',
+                  path: '/parent',
+                  uiRouterKey: 'parent',
+                  menuAttached: false,
+                  order: 0,
+                  collapsed: false,
+                  related: [{ documentId: 'rel-1', __type: 'api::author.author' }],
+                  parent: null,
+                },
+                {
+                  id: 2,
+                  documentId: 'item-2',
+                  title: 'Child Item',
+                  type: 'INTERNAL',
+                  path: '/child',
+                  uiRouterKey: 'child',
+                  menuAttached: false,
+                  order: 0,
+                  collapsed: false,
+                  related: [{ documentId: 'rel-2', __type: 'api::author.author' }],
+                  parent: {
+                    id: 1,
+                    documentId: 'item-1',
+                    title: 'Parent Item',
+                    type: 'INTERNAL',
+                    path: '/parent',
+                    uiRouterKey: 'parent',
+                    menuAttached: false,
+                    order: 0,
+                    collapsed: false,
+                    // related as an array
+                    related: [{ documentId: 'rel-1', __type: 'api::author.author' }],
+                  },
+                },
+              ],
+            }),
+          ];
+          mockFindMany.mockResolvedValue(mockData);
+
+          const repository = getNavigationRepository({ strapi: mockStrapi });
+
+          // When & Then - This should NOT throw, but currently does with:
+          // "Expected object, received array" at items[1].parent.related
+          await expect(repository.find({ filters: {}, locale: 'en' })).resolves.toBeDefined();
         });
       });
       describe('remove()', () => {


### PR DESCRIPTION
## Ticket
https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/658

## Summary
-  Fix ZodError (`"Expected object, received array"` at `items[N].parent.related`) when saving navigations with nested items
- Make `flattenRelated` recursive so it normalizes `related` from array to object on `parent` fields, not just top-level items
- Add unit test reproducing the issue

What does this PR do/solve?

The `related` field on navigation items is a `morphToMany` relation, which Strapi returns as an array. The `flattenRelated` utility converts it to a single object (`related?.[0]`), but only did so for the top-level item not for nested `parent` objects. When Strapi populated `parent.related` as an array, Zod schema validation failed with a 500 error, making it impossible to save navigations with nested items.


