### PR TITLE
fix: sort navigation items by order in buildNestedStructure

### DIFF
--- a/server/src/services/common/common.ts
+++ b/server/src/services/common/common.ts
@@ -448,22 +448,24 @@ const commonService = (context: { strapi: Core.Strapi }) => ({
     id,
   }: BuildNestedStructureInput): NavigationItemDBSchema[] {
     return (
-      navigationItems?.reduce((acc, navigationItem) => {
-        if (id && navigationItem.parent?.id !== id) {
+      (
+        navigationItems?.reduce((acc, navigationItem) => {
+          if (id && navigationItem.parent?.id !== id) {
+            return acc;
+          }
+
+          acc.push({
+            ...omit(navigationItem, ['related', 'items']),
+            related: navigationItem.related,
+            items: this.buildNestedStructure({
+              navigationItems,
+              id: navigationItem.id,
+            }),
+          });
+
           return acc;
-        }
-
-        acc.push({
-          ...omit(navigationItem, ['related', 'items']),
-          related: navigationItem.related,
-          items: this.buildNestedStructure({
-            navigationItems,
-            id: navigationItem.id,
-          }),
-        });
-
-        return acc;
-      }, [] as NavigationItemDBSchema[]) ?? []
+        }, [] as NavigationItemDBSchema[]) ?? []
+      )?.sort((a, b) => a.order - b.order) ?? []
     );
   },
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/662

## Summary

- Adds explicit `.sort((a, b) => a.order - b.order)` to `buildNestedStructure` in commonService to ensure navigation items are returned in correct order at every nesting level
